### PR TITLE
解决开启单独文件夹时重复创建文件夹的问题（Fix #43） 

### DIFF
--- a/android/app/src/main/kotlin/com/perol/pixez/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/perol/pixez/MainActivity.kt
@@ -151,7 +151,14 @@ class MainActivity : FlutterActivity() {
                 val folderName = names.first()
                 var folderDocument = treeDocument.findFile(folderName)
                 if (folderDocument == null) {
-                    folderDocument = treeDocument.createDirectory(folderName);
+                    val tempFolderDocument = treeDocument.createDirectory(folderName)
+                    folderDocument = treeDocument.findFile(folderName)
+                    if (tempFolderDocument != null && folderDocument != null) {
+                        if (!tempFolderDocument.getUri().equals(folderDocument.getUri())) {
+                            // 文件夹已经被创建过
+                            tempFolderDocument.delete()
+                        }
+                    }
                 }
                 val file = folderDocument?.findFile(fName)
                 if (file != null && file.exists()) {


### PR DESCRIPTION
没找到文件夹存在就不创建的 API，只能这样了

（好像不怎么清真