### PR TITLE
iPhone的高刷设置

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -79,5 +79,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
在info.plist文件中开启了iPhone的高刷设置权限，相关测试需要对于机型才能体现。