### PR TITLE
Compress image before uploading to SauceNAO

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -391,6 +391,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -391,13 +391,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0"
-  flutter_image_compress:
-    dependency: "direct main"
-    description:
-      name: flutter_image_compress
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -581,6 +574,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  image:
+    dependency: "direct main"
+    description:
+      name: image
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   dio_cache_interceptor: 3.2.7
   photo_view: ^0.13.0
   http_interceptor: 2.0.0-beta.2
+  flutter_image_compress: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   dio_cache_interceptor: 3.2.7
   photo_view: ^0.13.0
   http_interceptor: 2.0.0-beta.2
-  flutter_image_compress: ^1.1.0
+  image: ^3.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
> 我又来了

### 修改内容

使用 SauceNAO 搜索图片时，会将选中的图片压缩后再上传，压缩后图片的大小约为原图片的 10%~20% ；
此举能减少流量消耗，也能解决图片过大被 SauceNAO 拒绝的问题。

引入了新库 [flutter_image_compress](https://pub.dev/packages/flutter_image_compress)，仅测试了安卓端。

