### PR TITLE
使保存文件名编号左侧补0至3位

### DIFF
--- a/lib/store/save_store.dart
+++ b/lib/store/save_store.dart
@@ -392,7 +392,7 @@ abstract class _SaveStoreBase with Store {
     final result = userSetting.format!
         .replaceAll("{illust_id}", illust.id.toString())
         .replaceAll("{user_id}", illust.user.id.toString())
-        .replaceAll("{part}", index.toString())
+        .replaceAll("{part}", index.toString().padLeft(3, '0'))
         .replaceAll("{user_name}", illust.user.name.toString())
         .replaceAll("{title}", illust.title);
     return "$result$memType".toLegal();


### PR DESCRIPTION
不再输出p0，p1，p2...p10，p11，p12的编号
而是输出p001，p002，p003...p010，p011，p012的编号
使部分无法支持自然数排序的文件浏览器也可以正常排序图片