### PR TITLE
fix: tag历史无法导出

### DIFF
--- a/lib/store/tag_history_store.dart
+++ b/lib/store/tag_history_store.dart
@@ -88,7 +88,8 @@ abstract class _TagHistoryStoreBase with Store {
     final uriStr =
         await SAFPlugin.createFile("tag_history.json", "application/json");
     if (uriStr == null) return;
-    final exportData = ExportData(tagHisotry: tags);
+    await tagsPersistProvider.open();
+    final exportData = ExportData(tagHisotry: await tagsPersistProvider.getAllAccount());
     await SAFPlugin.writeUri(
         uriStr, Uint8List.fromList(utf8.encode(jsonEncode(exportData))));
   }


### PR DESCRIPTION
换手机后发现的bug,祖传搜索记录居然导不出来,遂怒水一pr