### PR TITLE
在关注列表中显示“H是不行的！“

### DIFF
--- a/lib/component/painer_card.dart
+++ b/lib/component/painer_card.dart
@@ -17,6 +17,8 @@
 import 'package:flutter/material.dart';
 import 'package:pixez/component/painter_avatar.dart';
 import 'package:pixez/component/pixiv_image.dart';
+import 'package:pixez/component/pixiv_image_shielded.dart';
+import 'package:pixez/main.dart';
 import 'package:pixez/models/user_preview.dart';
 import 'package:pixez/page/novel/user/novel_users_page.dart';
 import 'package:pixez/page/user/user_store.dart';
@@ -104,10 +106,22 @@ class PainterCard extends StatelessWidget {
                 SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
             delegate: SliverChildBuilderDelegate((context, index) {
               if (index >= user.illusts.length) return Container();
-              return PixivImage(
-                user.illusts[index].imageUrls.squareMedium,
-                fit: BoxFit.cover,
-              );
+              var currentIllust = user.illusts[index];
+              return PixivImageShielded(currentIllust.imageUrls.squareMedium,
+                  fit: BoxFit.cover, tags: currentIllust.tags);
+              // if (userSetting.hIsNotAllow) {
+              //   if (currentIllust.tags
+              //       .any((element) => element.name.startsWith('R-18'))) {
+              //     return Container(
+              //       color: Colors.white,
+              //       child: Image.asset('assets/images/h.jpg'),
+              //     );
+              //   }
+              // }
+              // return PixivImage(
+              //   currentIllust.imageUrls.squareMedium,
+              //   fit: BoxFit.cover,
+              // );
             }, childCount: user.illusts.length));
   }
 

--- a/lib/component/painer_card.dart
+++ b/lib/component/painer_card.dart
@@ -18,7 +18,6 @@ import 'package:flutter/material.dart';
 import 'package:pixez/component/painter_avatar.dart';
 import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/component/pixiv_image_shielded.dart';
-import 'package:pixez/main.dart';
 import 'package:pixez/models/user_preview.dart';
 import 'package:pixez/page/novel/user/novel_users_page.dart';
 import 'package:pixez/page/user/user_store.dart';
@@ -109,19 +108,6 @@ class PainterCard extends StatelessWidget {
               var currentIllust = user.illusts[index];
               return PixivImageShielded(currentIllust.imageUrls.squareMedium,
                   fit: BoxFit.cover, tags: currentIllust.tags);
-              // if (userSetting.hIsNotAllow) {
-              //   if (currentIllust.tags
-              //       .any((element) => element.name.startsWith('R-18'))) {
-              //     return Container(
-              //       color: Colors.white,
-              //       child: Image.asset('assets/images/h.jpg'),
-              //     );
-              //   }
-              // }
-              // return PixivImage(
-              //   currentIllust.imageUrls.squareMedium,
-              //   fit: BoxFit.cover,
-              // );
             }, childCount: user.illusts.length));
   }
 

--- a/lib/component/pixiv_image_shielded.dart
+++ b/lib/component/pixiv_image_shielded.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:mobx/mobx.dart';
 import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
@@ -34,26 +36,28 @@ class _PixivImageShieldedState extends State<PixivImageShielded> {
   late PixivImage? _pixivImage = null;
   @override
   Widget build(BuildContext context) {
-    if (userSetting.hIsNotAllow) {
-      if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
-        return Container(
-          color: Colors.white,
-          child: Image.asset('assets/images/h.jpg'),
+    return Observer(builder: (_) {
+      if (userSetting.hIsNotAllow) {
+        if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
+          return Container(
+            color: Colors.white,
+            child: Image.asset('assets/images/h.jpg'),
+          );
+        }
+      }
+      if (_pixivImage == null) {
+        _pixivImage = PixivImage(
+          widget.url,
+          placeWidget: widget.placeWidget,
+          fade: widget.fade,
+          fit: widget.fit,
+          enableMemoryCache: widget.enableMemoryCache,
+          height: widget.height,
+          width: widget.width,
+          host: widget.host,
         );
       }
-    }
-    if (_pixivImage == null) {
-      _pixivImage = PixivImage(
-        widget.url,
-        placeWidget: widget.placeWidget,
-        fade: widget.fade,
-        fit: widget.fit,
-        enableMemoryCache: widget.enableMemoryCache,
-        height: widget.height,
-        width: widget.width,
-        host: widget.host,
-      );
-    }
-    return _pixivImage ?? Container();
+      return _pixivImage ?? Container();
+    });
   }
 }

--- a/lib/component/pixiv_image_shielded.dart
+++ b/lib/component/pixiv_image_shielded.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:mobx/mobx.dart';
 import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
@@ -36,28 +35,30 @@ class _PixivImageShieldedState extends State<PixivImageShielded> {
   late PixivImage? _pixivImage = null;
   @override
   Widget build(BuildContext context) {
-    return Observer(builder: (_) {
-      if (userSetting.hIsNotAllow) {
-        if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
-          return Container(
-            color: Colors.white,
-            child: Image.asset('assets/images/h.jpg'),
+    return Observer(
+      builder: (_) {
+        if (userSetting.hIsNotAllow) {
+          if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
+            return Container(
+              color: Colors.white,
+              child: Image.asset('assets/images/h.jpg'),
+            );
+          }
+        }
+        if (_pixivImage == null) {
+          _pixivImage = PixivImage(
+            widget.url,
+            placeWidget: widget.placeWidget,
+            fade: widget.fade,
+            fit: widget.fit,
+            enableMemoryCache: widget.enableMemoryCache,
+            height: widget.height,
+            width: widget.width,
+            host: widget.host,
           );
         }
-      }
-      if (_pixivImage == null) {
-        _pixivImage = PixivImage(
-          widget.url,
-          placeWidget: widget.placeWidget,
-          fade: widget.fade,
-          fit: widget.fit,
-          enableMemoryCache: widget.enableMemoryCache,
-          height: widget.height,
-          width: widget.width,
-          host: widget.host,
-        );
-      }
-      return _pixivImage ?? Container();
-    });
+        return _pixivImage ?? Container();
+      },
+    );
   }
 }

--- a/lib/component/pixiv_image_shielded.dart
+++ b/lib/component/pixiv_image_shielded.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:pixez/component/pixiv_image.dart';
+import 'package:pixez/main.dart';
+import 'package:pixez/models/illust.dart';
+
+class PixivImageShielded extends StatefulWidget {
+  final String url;
+  final List<Tags> tags;
+  final Widget? placeWidget;
+  final bool fade;
+  final BoxFit? fit;
+  final bool? enableMemoryCache;
+  final double? height;
+  final double? width;
+  final String? host;
+
+  PixivImageShielded(
+    this.url, {
+    required this.tags,
+    this.placeWidget,
+    this.fade = true,
+    this.fit,
+    this.enableMemoryCache,
+    this.height,
+    this.host,
+    this.width,
+  });
+
+  @override
+  State<PixivImageShielded> createState() => _PixivImageShieldedState();
+}
+
+class _PixivImageShieldedState extends State<PixivImageShielded> {
+  late PixivImage? _pixivImage = null;
+  @override
+  Widget build(BuildContext context) {
+    if (userSetting.hIsNotAllow) {
+      if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
+        return Container(
+          color: Colors.white,
+          child: Image.asset('assets/images/h.jpg'),
+        );
+      }
+    }
+    if (_pixivImage == null) {
+      _pixivImage = PixivImage(
+        widget.url,
+        placeWidget: widget.placeWidget,
+        fade: widget.fade,
+        fit: widget.fit,
+        enableMemoryCache: widget.enableMemoryCache,
+        height: widget.height,
+        width: widget.width,
+        host: widget.host,
+      );
+    }
+    return _pixivImage ?? Container();
+  }
+}

--- a/lib/component/pixiv_image_shielded.dart
+++ b/lib/component/pixiv_image_shielded.dart
@@ -4,6 +4,11 @@ import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
 
+final hIsNotAllowedImage = Container(
+  color: Colors.white,
+  child: Image.asset('assets/images/h.jpg'),
+);
+
 class PixivImageShielded extends StatefulWidget {
   final String url;
   final List<Tags> tags;
@@ -39,10 +44,7 @@ class _PixivImageShieldedState extends State<PixivImageShielded> {
       builder: (_) {
         if (userSetting.hIsNotAllow) {
           if (widget.tags.any((tag) => tag.name.startsWith('R-18'))) {
-            return Container(
-              color: Colors.white,
-              child: Image.asset('assets/images/h.jpg'),
-            );
+            return hIsNotAllowedImage;
           }
         }
         if (_pixivImage == null) {


### PR DESCRIPTION
在**速览→已关注**界面中，图片的预览似乎并不会收到R18开关的影响
新增了一个类，将原来的`PixivImage`包裹起来，如果允许R18，则会返回这个PixivImage，反之则返回小穹
![e4d38be73fe7982ac2d0f805fcbc38bc_720](https://github.com/Notsfsssf/pixez-flutter/assets/87805157/80e55edd-69cb-47f4-ba93-597de00019d0)