### PR TITLE
feat: Implement secure window

### DIFF
--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -290,5 +290,6 @@
   "reply": "Reply",
   "reply_to": "Reply to",
   "show_feed_ai_badge": "Show feed AI badge",
-  "illust_detail_save_skip_confirm": "Skip confirmation when saving on details page"
+  "illust_detail_save_skip_confirm": "Skip confirmation when saving on details page",
+  "secure_window": "Secure window"
 }

--- a/lib/page/hello/hello_page.dart
+++ b/lib/page/hello/hello_page.dart
@@ -15,6 +15,7 @@
  */
 
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/component/painter_avatar.dart';
@@ -30,6 +31,7 @@ import 'package:pixez/page/hello/recom/recom_spotlight_page.dart';
 import 'package:pixez/page/hello/setting/setting_page.dart';
 import 'package:pixez/page/preview/preview_page.dart';
 import 'package:pixez/page/search/search_page.dart';
+import 'package:pixez/utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class HelloPage extends StatefulWidget {
@@ -62,6 +64,9 @@ class _HelloPageState extends State<HelloPage> {
     });
     initLinksStream();
     initPlatformState();
+    if (Platform.isAndroid || Platform.isIOS) {
+      configSecureWindow(userSetting.secureWindow);
+    }
   }
 
   Future<void> initPlatformState() async {

--- a/lib/page/hello/hello_page.dart
+++ b/lib/page/hello/hello_page.dart
@@ -15,7 +15,6 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/component/painter_avatar.dart';
@@ -31,7 +30,6 @@ import 'package:pixez/page/hello/recom/recom_spotlight_page.dart';
 import 'package:pixez/page/hello/setting/setting_page.dart';
 import 'package:pixez/page/preview/preview_page.dart';
 import 'package:pixez/page/search/search_page.dart';
-import 'package:pixez/utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class HelloPage extends StatefulWidget {
@@ -64,9 +62,6 @@ class _HelloPageState extends State<HelloPage> {
     });
     initLinksStream();
     initPlatformState();
-    if (Platform.isAndroid || Platform.isIOS) {
-      configSecureWindow(userSetting.secureWindow);
-    }
   }
 
   Future<void> initPlatformState() async {

--- a/lib/page/hello/setting/setting_quality_page.dart
+++ b/lib/page/hello/setting/setting_quality_page.dart
@@ -291,6 +291,12 @@ class _SettingQualityPageState extends State<SettingQualityPage>
                   if (!value) BotToast.showText(text: 'H是可以的！(ˉ﹃ˉ)');
                   userSetting.setHIsNotAllow(value);
                 }),
+            if (Platform.isAndroid || Platform.isIOS) SwitchListTile(
+                value: userSetting.secureWindow,
+                title: Text(I18n.of(context).secure_window),
+                onChanged: (value) async {
+                  userSetting.setSecureWindow(value);
+                }),
             SwitchListTile(
                 value: userSetting.isReturnAgainToExit,
                 title: Text(I18n.of(context).return_again_to_exit),

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -445,6 +445,9 @@ abstract class _UserSetting with Store {
     }
     format = prefs.getString(SAVE_FORMAT_KEY);
     if (format == null || format!.isEmpty) format = intialFormat;
+    if (Platform.isAndroid || Platform.isIOS) {
+      await configSecureWindow(secureWindow);
+    }
   }
 
   int toRealLanguageNum(int num) {

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -25,6 +25,7 @@ import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:pixez/page/about/languages.dart';
+import 'package:pixez/utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 part 'user_setting.g.dart';
@@ -77,6 +78,7 @@ abstract class _UserSetting with Store {
   static const String FEED_AI_BADGE_KEY = "feed_ai_badge";
   static const String ILLUST_DETAIL_SAVE_SKIP_LONG_PRESS_KEY =
       "illust_detail_save_skip_long_press";
+  static const String SECURE_WINDOW_KEY = "secure_window";
 
   @observable
   bool illustDetailSaveSkipLongPress = false;
@@ -131,6 +133,8 @@ abstract class _UserSetting with Store {
   bool overSanityLevelFolder = false;
   @observable
   bool hIsNotAllow = false;
+  @observable
+  bool secureWindow = false;
   @observable
   bool followAfterStar = false;
   @observable
@@ -398,6 +402,7 @@ abstract class _UserSetting with Store {
     singleFolder = prefs.getBool(SINGLE_FOLDER_KEY) ?? false;
     displayMode = prefs.getInt('display_mode');
     hIsNotAllow = prefs.getBool('h_is_not_allow') ?? false;
+    secureWindow = prefs.getBool(SECURE_WINDOW_KEY) ?? false;
     pictureQuality = prefs.getInt(PICTURE_QUALITY_KEY) ?? 0;
     mangaQuality = prefs.getInt(MANGA_QUALITY_KEY) ?? 0;
     isBangs = prefs.getBool(IS_BANGS_KEY) ?? false;
@@ -504,6 +509,13 @@ abstract class _UserSetting with Store {
   setHIsNotAllow(bool value) async {
     await prefs.setBool('h_is_not_allow', value);
     hIsNotAllow = value;
+  }
+
+  @action
+  setSecureWindow(bool value) async {
+    await prefs.setBool(SECURE_WINDOW_KEY, value);
+    secureWindow = value;
+    await configSecureWindow(value);
   }
 
   @action

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+import 'package:privacy_screen/privacy_screen.dart';
 
 /// 当使用鼠标滚轮滚动时 距离底边还有多少距离时开始加载下一页
 const double kLazyLoadSize = 300;
@@ -27,4 +28,24 @@ void Function()? initializeScrollController(
 
   controller.addListener(listener);
   return () => controller.removeListener(listener);
+}
+
+Future<void> configSecureWindow(bool enabled) async {
+  try {
+    if (enabled) {
+      await PrivacyScreen.instance.enable(
+        iosOptions: const PrivacyIosOptions(
+          enablePrivacy: true,
+          lockTrigger: IosLockTrigger.didEnterBackground,
+        ),
+        androidOptions: const PrivacyAndroidOptions(
+          enableSecure: true,
+        )
+    );
+    } else {
+      await PrivacyScreen.instance.disable();
+    }
+  } catch (e) {
+    print(e);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   # Desktop Support
   flutter_acrylic: ^1.1.3
   window_manager: ^0.3.7
+  privacy_screen: ^0.0.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Resolves #303 

It's currently implemented using [`privacy_screen`](https://pub.dev/packages/privacy_screen), but I can implement it using the platform channel as well.


Also, I wasn't sure where to put the `configSecureWindow` function, so I put it in `utils.dart` for now.