### PR TITLE
feat: 顯示完整使用者橫幅

### DIFF
--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -227,7 +227,7 @@
       }
     }
   },
-  "save_painter_avatar": "save painter avatar",
+  "save_painter_avatar": "Save painter avatar",
   "favorited_tag": "Favorited Tags",
   "legacy_mode_warning": "legacy mode is not available since Android9",
   "clear_old_format_file": "Clear old format file",

--- a/lib/page/user/users_page.dart
+++ b/lib/page/user/users_page.dart
@@ -435,6 +435,18 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
                           builder: (context) {
                             return AlertDialog(
                               title: Text(I18n.of(context).save),
+                              content: ClipRRect(
+                                borderRadius: BorderRadius.circular(12),
+                                child: CachedNetworkImage(
+                                  imageUrl: userStore.userDetail!.profile
+                                      .background_image_url!,
+                                  fit: BoxFit.cover,
+                                  cacheManager: pixivCacheManager,
+                                  httpHeaders: Hoster.header(
+                                      url: userStore.userDetail!.profile
+                                          .background_image_url),
+                                ),
+                              ),
                               actions: [
                                 TextButton(
                                     onPressed: () async {
@@ -691,6 +703,18 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
                         builder: (context) {
                           return AlertDialog(
                             title: Text(I18n.of(context).save_painter_avatar),
+                            content: ClipRRect(
+                              borderRadius: BorderRadius.circular(12),
+                              child: CachedNetworkImage(
+                                imageUrl:
+                                    userStore.user!.profileImageUrls.medium,
+                                fit: BoxFit.cover,
+                                cacheManager: pixivCacheManager,
+                                httpHeaders: Hoster.header(
+                                    url: userStore
+                                        .user!.profileImageUrls.medium),
+                              ),
+                            ),
                             actions: [
                               TextButton(
                                   onPressed: () async {

--- a/lib/page/user/users_page.dart
+++ b/lib/page/user/users_page.dart
@@ -247,7 +247,12 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
           pinned: true,
           elevation: 0.0,
           forceElevated: innerBoxIsScrolled ?? false,
-          expandedHeight: 280,
+          expandedHeight:
+              userStore.userDetail?.profile.background_image_url != null
+                  ? MediaQuery.of(context).size.width / 2 +
+                      205 -
+                      MediaQuery.of(context).padding.top
+                  : 300,
           leading: CommonBackArea(),
           actions: <Widget>[
             Builder(builder: (context) {
@@ -418,7 +423,9 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
   Widget _buildBackground(BuildContext context) {
     return Container(
         width: MediaQuery.of(context).size.width,
-        height: MediaQuery.of(context).padding.top + 160,
+        height: userStore.userDetail?.profile.background_image_url != null
+            ? MediaQuery.of(context).size.width / 2
+            : MediaQuery.of(context).padding.top + 160,
         child: userStore.userDetail != null
             ? userStore.userDetail!.profile.background_image_url != null
                 ? InkWell(
@@ -760,10 +767,10 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
       final dio = Dio(BaseOptions(headers: Hoster.header(url: url)));
       if (!userSetting.disableBypassSni) {
         dio.httpClientAdapter = IOHttpClientAdapter()
-          ..onHttpClientCreate = (client) {
-            client.badCertificateCallback =
-                (X509Certificate cert, String host, int port) => true;
-            return client;
+          ..createHttpClient = () {
+            return HttpClient()
+              ..badCertificateCallback =
+                  (X509Certificate cert, String host, int port) => true;
           };
       }
       await dio.download(url.toTrueUrl(), tempFile, deleteOnError: true);


### PR DESCRIPTION
Resolves #585 

* 完整顯示使用者橫幅，並且在保存個人檔案照片和橫幅時顯示圖片預覽
* 修改英文標題的大小寫錯誤
* 將 Dio 棄用的 `onHttpClientCreate` 更新為 `createHttpClient`

在 iPhone 15 Pro Max, iPhone SE, Pixel 6 上測試正常