### PR TITLE
更大的收藏按钮

### DIFF
--- a/lib/component/star_icon.dart
+++ b/lib/component/star_icon.dart
@@ -50,8 +50,9 @@ class _StarIconState extends State<StarIcon> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 36,
+      width: 40,
       height: 40,
+      color: Colors.transparent,
       child: _buildData(state),
     );
   }


### PR DESCRIPTION
现在收藏按钮是方的，包含了图标外面空的部分，不需要精确的点击到内部的图标，与0.7.2之前的版本一致