### PR TITLE
Replace androidndkgif's identifier & version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     implementation("io.coil-kt:coil:2.6.0")
 //    implementation("androidx.webkit:webkit:1.4.0")
     implementation("androidx.browser:browser:1.8.0")
-    implementation("com.waynejo:androidndkgif:0.3.3")
+    implementation("io.github.waynejo:androidndkgif:1.0.1")
     implementation("androidx.preference:preference-ktx:1.2.1")
     implementation("androidx.documentfile:documentfile:1.0.1")
 }


### PR DESCRIPTION
JCenter is closed, original package cannot be found and the identifier has changed.