### PR TITLE
🔧 添加flutter_lints校验

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,40 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # - prefer_relative_imports
+    - always_declare_return_types
+    - avoid_bool_literals_in_conditional_expressions
+    - avoid_escaping_inner_quotes
+    - avoid_unnecessary_containers
+    - lines_longer_than_80_chars
+    - no_literal_bool_comparisons
+    - package_api_docs
+    - sized_box_for_whitespace
+    - sized_box_shrink_expand
+    - unawaited_futures
+    - unnecessary_final
+    - unnecessary_lambdas
+    - void_checks
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,6 +93,7 @@ dev_dependencies:
   custom_lint: ^0.6.4
   riverpod_lint: ^2.3.10
   freezed: ^2.5.2
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
添加 `flutter_lints` 包并添加一些规则用于校验，包括：

- `always_declare_return_types`: 声明方法或函数时，始终要指定返回类型
- `avoid_bool_literals_in_conditional_expressions`: 避免在条件表达式中使用bool值 condition ? true : boolExpression
- `avoid_escaping_inner_quotes`: 通过双引号来消除字符串中的转义字符
- `avoid_unnecessary_containers`: 没有必要的containers 会造成Widget树臃肿
- `lines_longer_than_80_chars`: 单行长度不超过80字符
- `no_literal_bool_comparisons`: boolean值之间不要比较： if(isTrue == true) 改为if(isTrue)
- `package_api_docs`: 公用API要提供注释
- `sized_box_for_whitespace`: 布局添加空白使用sizebox代替container
- `sized_box_shrink_expand`: 使用SizedBox.shrink(...) 和 SizedBox.expand(...)代替空的 SizedBox
- `unawaited_futures`: Future 方法调用必须使用 `await`
- `unnecessary_final`:非必要final采用var
- `unnecessary_lambdas`:当可以使用分离（tear-off）时，不要创建 lambda。
- `void_checks`: 不要给void类型的变量赋值