### PR TITLE
feat: enhance homepage, detail page and search filter function

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -97,10 +97,10 @@ android {
 
     signingConfigs {
         create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
+            keyAlias = keystoreProperties["keyAlias"]?.toString()
+            keyPassword = keystoreProperties["keyPassword"]?.toString()
             storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+            storePassword = keystoreProperties["storePassword"]?.toString()
         }
     }
 

--- a/lib/component/illust_card.dart
+++ b/lib/component/illust_card.dart
@@ -204,6 +204,11 @@ class _IllustCardState extends State<IllustCard> {
                               _buildVisibility()
                             ],
                           )),
+                      Positioned(
+                        bottom: 5.0,
+                        left: 5.0,
+                        child: _buildStatsBadge(),
+                      ),
                       // Positioned(
                       //   top: 0,
                       //   left: 0,
@@ -241,6 +246,46 @@ class _IllustCardState extends State<IllustCard> {
             ],
           ),
         ));
+  }
+
+  Widget _buildStatsBadge() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.visibility, color: Colors.white, size: 12),
+            SizedBox(width: 2),
+            Text(
+              "${_abbreviateNumber(store.illusts!.totalView)}",
+              style: TextStyle(color: Colors.white, fontSize: 12),
+            ),
+            SizedBox(width: 4),
+            Icon(Icons.bookmark, color: Colors.white, size: 12),
+            SizedBox(width: 2),
+            Text(
+              "${_abbreviateNumber(store.illusts!.totalBookmarks)}",
+              style: TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _abbreviateNumber(int number) {
+    if (number >= 1000000) {
+      return '${(number / 1000000).toStringAsFixed(1)}M';
+    } else if (number >= 1000) {
+      return '${(number / 1000).toStringAsFixed(1)}K';
+    } else {
+      return number.toString();
+    }
   }
 
   Widget _buildAIBadge() {

--- a/lib/component/illust_card.dart
+++ b/lib/component/illust_card.dart
@@ -195,6 +195,11 @@ class _IllustCardState extends State<IllustCard> {
                       Positioned.fill(child: _buildPic(tag, tooLong)),
                       Positioned(
                           top: 5.0,
+                          left: 5.0,
+                          child: _buildR18Badge(),
+                      ),
+                      Positioned(
+                          top: 5.0,
                           right: 5.0,
                           child: Row(
                             children: [
@@ -299,6 +304,31 @@ class _IllustCardState extends State<IllustCard> {
         child: Text(
           "AI",
           style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildR18Badge() {
+    String text = "";
+    if (store.illusts!.xRestrict == 2) {
+      text = "R-18G";
+    } else if (store.illusts!.xRestrict == 1) {
+      text = "R-18";
+    }
+
+    if (text.isEmpty) return Container();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.red,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Text(
+          text,
+          style: TextStyle(color: Colors.white, fontSize: 12),
         ),
       ),
     );

--- a/lib/component/multi_function_fab.dart
+++ b/lib/component/multi_function_fab.dart
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2020. by perol_notsf, All rights reserved
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import 'package:flutter/material.dart';
+import 'package:pixez/main.dart';
+import 'package:pixez/page/novel/novel_rail.dart';
+
+class MultiFunctionFab extends StatefulWidget {
+  final VoidCallback onRefresh;
+
+  const MultiFunctionFab({Key? key, required this.onRefresh}) : super(key: key);
+
+  @override
+  _MultiFunctionFabState createState() => _MultiFunctionFabState();
+}
+
+class _MultiFunctionFabState extends State<MultiFunctionFab>
+    with SingleTickerProviderStateMixin {
+  bool _isExpanded = false;
+  late AnimationController _animationController;
+  late Animation<Offset> _slideAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      duration: Duration(milliseconds: 150),
+      vsync: this,
+    );
+    _slideAnimation = Tween<Offset>(
+      begin: Offset(0, 1),
+      end: Offset(0, 0),
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.linear,
+    ));
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _toggleExpanded() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+      if (_isExpanded) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        // 跳转到小说首页按钮
+        if (_isExpanded)
+          SlideTransition(
+            position: _slideAnimation,
+            child: Container(
+              margin: EdgeInsets.only(bottom: 16),
+              child: FloatingActionButton(
+                heroTag: "fab_novel",
+                onPressed: () {
+                  Navigator.of(context).push(MaterialPageRoute(
+                      builder: (context) => NovelRail()));
+                  _toggleExpanded();
+                },
+                child: Icon(Icons.book),
+                mini: true,
+              ),
+            ),
+          ),
+        // 回到顶部按钮
+        if (_isExpanded)
+          SlideTransition(
+            position: _slideAnimation,
+            child: Container(
+              margin: EdgeInsets.only(bottom: 16),
+              child: FloatingActionButton(
+                heroTag: "fab_top",
+                onPressed: () {
+                  // 发送回到顶部信号
+                  topStore.setTop("100");
+                  _toggleExpanded();
+                },
+                child: Icon(Icons.arrow_upward),
+                mini: true,
+              ),
+            ),
+          ),
+        // 刷新按钮
+        if (_isExpanded)
+          SlideTransition(
+            position: _slideAnimation,
+            child: Container(
+              margin: EdgeInsets.only(bottom: 16),
+              child: FloatingActionButton(
+                heroTag: "fab_refresh",
+                onPressed: () {
+                  widget.onRefresh();
+                  _toggleExpanded();
+                },
+                child: Icon(Icons.refresh),
+                mini: true,
+              ),
+            ),
+          ),
+        // 主按钮
+        FloatingActionButton(
+          heroTag: "fab_main",
+          onPressed: _toggleExpanded,
+          child: Icon(_isExpanded ? Icons.close : Icons.menu),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/page/hello/android_hello_page.dart
+++ b/lib/page/hello/android_hello_page.dart
@@ -59,6 +59,11 @@ class _AndroidHelloPageState extends State<AndroidHelloPage> {
     fullScreenStore.toggle();
   }
 
+  void _refreshCurrentPage() {
+    // 发送刷新信号"101"，专门用于触发刷新操作
+    topStore.setTop("101");
+  }
+
   @override
   Widget build(BuildContext context) {
     return Observer(builder: (context) {
@@ -123,6 +128,12 @@ class _AndroidHelloPageState extends State<AndroidHelloPage> {
                       child: _buildNavigationBar(context),
                     );
                   }),
+            floatingActionButton: index == 0
+                ? FloatingActionButton(
+                    child: Icon(Icons.refresh),
+                    onPressed: _refreshCurrentPage,
+                  )
+                : null,
           ));
     });
   }

--- a/lib/page/hello/android_hello_page.dart
+++ b/lib/page/hello/android_hello_page.dart
@@ -25,6 +25,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:pixez/component/painter_avatar.dart';
+import 'package:pixez/component/multi_function_fab.dart';
 import 'package:pixez/constants.dart';
 import 'package:pixez/deep_link_plugin.dart';
 import 'package:pixez/er/leader.dart';
@@ -128,12 +129,6 @@ class _AndroidHelloPageState extends State<AndroidHelloPage> {
                       child: _buildNavigationBar(context),
                     );
                   }),
-            floatingActionButton: index == 0
-                ? FloatingActionButton(
-                    child: Icon(Icons.refresh),
-                    onPressed: _refreshCurrentPage,
-                  )
-                : null,
           ));
     });
   }
@@ -143,12 +138,22 @@ class _AndroidHelloPageState extends State<AndroidHelloPage> {
       children: [
         _buildPageContent(context),
         Positioned(
-          bottom: MediaQuery.of(context).padding.bottom + 16,
+          bottom: MediaQuery.of(context).padding.bottom + 80, // 调整位置，避免被导航栏遮挡
           right: 16,
           child: Observer(builder: (context) {
-            return AnimatedToggleFullscreenFAB(
-                isFullscreen: fullScreenStore.fullscreen,
-                toggleFullscreen: toggleFullscreen);
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (index == 0) // 只在首页显示多功能按钮
+                  MultiFunctionFab(
+                    onRefresh: _refreshCurrentPage,
+                  ),
+                AnimatedToggleFullscreenFAB(
+                  isFullscreen: fullScreenStore.fullscreen,
+                  toggleFullscreen: toggleFullscreen,
+                ),
+              ],
+            );
           }),
         )
       ],

--- a/lib/page/hello/android_hello_page.dart
+++ b/lib/page/hello/android_hello_page.dart
@@ -134,30 +134,40 @@ class _AndroidHelloPageState extends State<AndroidHelloPage> {
   }
 
   Widget _buildPageView(BuildContext context) {
-    return Stack(
-      children: [
-        _buildPageContent(context),
-        Positioned(
-          bottom: MediaQuery.of(context).padding.bottom + 80, // 调整位置，避免被导航栏遮挡
-          right: 16,
-          child: Observer(builder: (context) {
-            return Column(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (index == 0) // 只在首页显示多功能按钮
-                  MultiFunctionFab(
-                    onRefresh: _refreshCurrentPage,
+    return LayoutBuilder(builder: (context, constraints) {
+      final wide = constraints.maxWidth > constraints.maxHeight;
+      return Stack(
+        children: [
+          _buildPageContent(context),
+          Positioned(
+            bottom: wide 
+                ? 16 // 横屏时使用较小的底部边距
+                : MediaQuery.of(context).padding.bottom + 16, // 竖屏时避免被导航栏遮挡
+            right: 16,
+            child: Observer(builder: (context) {
+              return Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  // 只在首页显示多功能按钮
+                  if (index == 0)
+                    MultiFunctionFab(
+                      onRefresh: _refreshCurrentPage,
+                    ),
+                  // 当同时显示多功能按钮和全屏按钮时添加间距
+                  if (index == 0 && fullScreenStore.fullscreen)
+                    SizedBox(height: 8),
+                  // 显示全屏切换按钮
+                  AnimatedToggleFullscreenFAB(
+                    isFullscreen: fullScreenStore.fullscreen,
+                    toggleFullscreen: toggleFullscreen,
                   ),
-                AnimatedToggleFullscreenFAB(
-                  isFullscreen: fullScreenStore.fullscreen,
-                  toggleFullscreen: toggleFullscreen,
-                ),
-              ],
-            );
-          }),
-        )
-      ],
-    );
+                ],
+              );
+            }),
+          )
+        ],
+      );
+    });
   }
 
   Widget _buildNavigationBar(BuildContext context) {

--- a/lib/page/hello/recom/recom_spotlight_page.dart
+++ b/lib/page/hello/recom/recom_spotlight_page.dart
@@ -73,9 +73,35 @@ class _RecomSpolightPageState extends State<RecomSpolightPage>
     )..easyRefreshController = _easyRefreshController;
     super.initState();
     subscription = topStore.topStream.listen((event) {
+      // 处理返回顶部信号
       if (event == "100") {
-        _scrollController.position.jumpTo(0);
+        _scrollToTop();
       }
+      // 处理刷新信号
+      else if (event == "101") {
+        _triggerRefreshAnimation();
+      }
+    });
+  }
+
+  /// 滚动到页面顶部
+  void _scrollToTop() {
+    if (_scrollController.hasClients) {
+      _scrollController.position.jumpTo(0);
+    }
+  }
+
+  /// 触发刷新动画和操作
+  void _triggerRefreshAnimation() {
+    // 先滚动到顶部，然后延迟触发刷新动画，确保动画能完整显示
+    _scrollToTop();
+    
+    // 使用addPostFrameCallback确保滚动完成后才触发刷新
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // 添加一个小延迟确保滚动完成
+      Future.delayed(Duration(milliseconds: 100), () {
+        _easyRefreshController.callRefresh();
+      });
     });
   }
 

--- a/lib/page/picture/illust_lighting_page.dart
+++ b/lib/page/picture/illust_lighting_page.dart
@@ -466,15 +466,99 @@ class _IllustVerticalPageState extends State<IllustVerticalPage>
                     }
                     saveStore.saveImage(_aboutStore.illusts[index]);
                   },
-                  child: PixivImage(
-                    _aboutStore.illusts[index].imageUrls.squareMedium,
-                    enableMemoryCache: false,
+                  child: Stack(
+                    children: [
+                      PixivImage(
+                        _aboutStore.illusts[index].imageUrls.squareMedium,
+                        enableMemoryCache: false,
+                      ),
+                      // 添加标记
+                      Positioned(
+                        top: 5.0,
+                        left: 5.0,
+                        child: _buildR18Badge(_aboutStore.illusts[index]),
+                      ),
+                      Positioned(
+                        top: 5.0,
+                        right: 5.0,
+                        child: Row(
+                          children: [
+                            if (userSetting.feedAIBadge &&
+                                _aboutStore.illusts[index].illustAIType == 2)
+                              _buildAIBadge(),
+                            _buildPageCountBadge(_aboutStore.illusts[index]),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
                 );
               }, childCount: _aboutStore.illusts.length),
               gridDelegate:
                   SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3))
         ],
+      ),
+    );
+  }
+
+  // 构建AI标记
+  Widget _buildAIBadge() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 2.0),
+        child: Text(
+          "AI",
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
+      ),
+    );
+  }
+
+  // 构建R18/R18G标记
+  Widget _buildR18Badge(Illusts illust) {
+    String text = "";
+    if (illust.xRestrict == 2) {
+      text = "R-18G";
+    } else if (illust.xRestrict == 1) {
+      text = "R-18";
+    }
+
+    if (text.isEmpty) return Container();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.red,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Text(
+          text,
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
+      ),
+    );
+  }
+
+  // 构建页数标记
+  Widget _buildPageCountBadge(Illusts illust) {
+    if (illust.pageCount <= 1) return Container();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Text(
+          illust.pageCount.toString(),
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
       ),
     );
   }

--- a/lib/page/picture/illust_row_page.dart
+++ b/lib/page/picture/illust_row_page.dart
@@ -369,14 +369,97 @@ class _IllustRowPageState extends State<IllustRowPage>
                         userSetting.defaultPrivateLike ? "private" : "public");
               }
             },
-            child: PixivImage(
-              _aboutStore.illusts[index].imageUrls.squareMedium,
-              enableMemoryCache: false,
+            child: Stack(
+              children: [
+                PixivImage(
+                  _aboutStore.illusts[index].imageUrls.squareMedium,
+                  enableMemoryCache: false,
+                ),
+                Positioned(
+                  top: 5.0,
+                  left: 5.0,
+                  child: _buildR18Badge(_aboutStore.illusts[index]),
+                ),
+                Positioned(
+                  top: 5.0,
+                  right: 5.0,
+                  child: Row(
+                    children: [
+                      if (userSetting.feedAIBadge &&
+                          _aboutStore.illusts[index].illustAIType == 2)
+                        _buildAIBadge(),
+                      _buildPageCountBadge(_aboutStore.illusts[index]),
+                    ],
+                  ),
+                ),
+              ],
             ),
           );
         }, childCount: _aboutStore.illusts.length),
         gridDelegate:
             SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3));
+  }
+
+  // 构建AI标记
+  Widget _buildAIBadge() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 2.0),
+        child: Text(
+          "AI",
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
+      ),
+    );
+  }
+
+  // 构建R18/R18G标记
+  Widget _buildR18Badge(Illusts illust) {
+    String text = "";
+    if (illust.xRestrict == 2) {
+      text = "R-18G";
+    } else if (illust.xRestrict == 1) {
+      text = "R-18";
+    }
+
+    if (text.isEmpty) return Container();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.red,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Text(
+          text,
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
+      ),
+    );
+  }
+
+  // 构建页数标记
+  Widget _buildPageCountBadge(Illusts illust) {
+    if (illust.pageCount <= 1) return Container();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black26,
+        borderRadius: BorderRadius.all(Radius.circular(4.0)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 4.0),
+        child: Text(
+          illust.pageCount.toString(),
+          style: TextStyle(color: Colors.white, fontSize: 12),
+        ),
+      ),
+    );
   }
 
   List<Widget> _buildPhotoList(Illusts data, bool centerType, double height) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -365,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio_cache_interceptor
-      sha256: "855dec6d98b1fb3d63f462f6718f0b67d3d09476c37a52a0146fd6ce03622407"
+      sha256: ac9f312e5a81d79cbccb15f56b78aeae7343a981c1d7c169b11194fae806ec0b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.0.5"
   dio_compatibility_layer:
     dependency: "direct main"
     description:
@@ -1500,10 +1500,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      sha256: "0b0f98d535319cb5cdd4f65783c2a54ee6d417a2f093dbb18be3e36e4c3d181f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.14"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1649,10 +1649,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: f393d92c71bdcc118d6203d07c991b9be0f84b1a6f89dd4f7eed348131329924
+      sha256: "5c225083e72ea56c96d94ba1dd14fb89c8bb7731c8496ee840ab77be9bb67ae2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1745,10 +1745,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "199bc33e746088546a39cc5f36bac5a278c5e53b40cb3196f99e7345fdcfae6b"
+      sha256: c0fb544b9ac7efa10254efaf00a951615c362d1ea1877472f8f6c0fa00fcf15b
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.22"
+    version: "6.3.23"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1905,10 +1905,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   waterfall_flow:
     dependency: "direct main"
     description:
@@ -1953,10 +1953,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "3c4eb4fcc252b40c2b5ce7be20d0481428b70f3ff589b0a8b8aaeb64c6bed701"
+      sha256: "21507ea5a326ceeba4d29dea19e37d92d53d9959cfc746317b9f9f7a57418d87"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.2"
+    version: "4.10.3"
   webview_flutter_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
## 概述
**为应用首页、图片详情页和搜索页新增几项增强功能，主要根据我自身使用习惯添加**
包括：
- 首页新增多功能悬浮按钮（回到顶部、刷新、小说入口）
- 图片卡片补充观看数、收藏数及年龄分级标识（R18/R18G）
- 图片详情页推荐区域同步展示内容标签（R18/R18G、AI、页数）
- 搜索筛选器新增多个年龄分级选项


## 具体变更

### 1. 首页多功能悬浮按钮
- 在首页右下角添加一个多功能按钮（Floating Action Button）
- 点击后展开三个操作项：
  - **回到顶部**：快速滚动至列表顶部
  - **刷新页面**：重新加载当前数据
  - **小说入口**：跳转至小说相关页面（若已实现）

### 2. 首页图片卡片信息增强
- **左下角**：显示图片的 **观看数** 与 **收藏数**（格式：👁️ 1.2k / ❤️ 345）
- **左上角**：根据插画标签自动显示 **R-18** 或 **R-18G** 标识（红底白字）

### 3. 图片详情页推荐区域优化
- 在“相关推荐”卡片中，统一添加内容标识：
  - `R18` / `R18G`
  - `AI`（若为 AI 生成作品）
  - 页数

### 4. 搜索筛选器扩展
- 在搜索页的“年龄分级”筛选项中，新增以下选项：
  - 安全（Safe）
  - R18
  - R18G
- 用户可多选或单选，提升内容过滤灵活性


