### PR TITLE
feat(search): 新增搜索动图 (Ugoira) 过滤功能并优化筛选器设置保存逻辑

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -5,6 +5,8 @@
   "account_message": "Account info",
   "ai_generated": "AI-generated",
   "all": "All",
+  "ugoira_only": "Only Ugoira",
+  "ugoira_none": "No Ugoira",
   "already_in_query": "Already in queue",
   "already_saved": "Already saved",
   "android_special_setting": "Android-specific Settings",

--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -5,6 +5,8 @@
   "account_message": "Account info",
   "ai_generated": "AI-generated",
   "all": "All",
+  "ugoira_only": "Only Ugoira",
+  "ugoira_none": "No Ugoira",
   "already_in_query": "Already in queue",
   "already_saved": "Already saved",
   "android_special_setting": "Android-specific Settings",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -5,6 +5,8 @@
   "account_message": "アカウント",
   "ai_generated": "AI 生成",
   "all": "全て",
+  "ugoira_only": "うごイラのみ",
+  "ugoira_none": "うごイラ以外",
   "already_in_query": "キューに追加済",
   "already_saved": "保存済み",
   "android_special_setting": "Android 向けの設定",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -5,6 +5,8 @@
   "account_message": "账户信息",
   "ai_generated": "AI 生成",
   "all": "全部",
+  "ugoira_only": "仅动图",
+  "ugoira_none": "不含动图",
   "already_in_query": "已在列队",
   "already_saved": "已存在",
   "android_special_setting": "安卓设定",

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -5,6 +5,8 @@
   "account_message": "账户信息",
   "ai_generated": "AI 生成",
   "all": "全部",
+  "ugoira_only": "仅动图",
+  "ugoira_none": "不含动图",
   "already_in_query": "已在列队",
   "already_saved": "已存在",
   "android_special_setting": "安卓设定",

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -5,6 +5,8 @@
   "account_message": "帳戶資訊",
   "ai_generated": "AI 生成",
   "all": "全部",
+  "ugoira_only": "僅動圖",
+  "ugoira_none": "不含動圖",
   "already_in_query": "已位於佇列中",
   "already_saved": "已存在",
   "android_special_setting": "Android 平台專有設定",

--- a/lib/lighting/lighting_page.dart
+++ b/lib/lighting/lighting_page.dart
@@ -27,6 +27,7 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/lighting/lighting_store.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
+import 'package:pixez/page/picture/illust_store.dart';
 import 'package:waterfall_flow/waterfall_flow.dart';
 
 class WaterFallLoading extends StatefulWidget {
@@ -52,6 +53,7 @@ class LightingList extends StatefulWidget {
   final ScrollController? scrollController;
   final String? portal;
   final bool? ai;
+  final bool Function(Illusts)? filter;
 
   const LightingList(
       {Key? key,
@@ -60,7 +62,8 @@ class LightingList extends StatefulWidget {
       this.isNested,
       this.scrollController,
       this.portal,
-      this.ai})
+      this.ai,
+      this.filter})
       : super(key: key);
 
   @override
@@ -133,8 +136,13 @@ class _LightingListState extends State<LightingList> {
   late EasyRefreshController _refreshController;
 
   Widget _buildWithoutHeader(context) {
-    _store.iStores
-        .removeWhere((element) => element.illusts!.hateByUser(ai: _ai));
+    _store.iStores.removeWhere((element) {
+      if (element.illusts!.hateByUser(ai: _ai)) return true;
+      if (widget.filter != null && !widget.filter!(element.illusts!)) {
+        return true;
+      }
+      return false;
+    });
     return NotificationListener<ScrollNotification>(
         onNotification: (ScrollNotification notification) {
           if (widget.isNested == true) {
@@ -276,8 +284,13 @@ class _LightingListState extends State<LightingList> {
 
   SliverChildBuilderDelegate _buildSliverChildBuilderDelegate(
       BuildContext context) {
-    _store.iStores
-        .removeWhere((element) => element.illusts!.hateByUser(ai: _ai));
+    _store.iStores.removeWhere((element) {
+      if (element.illusts!.hateByUser(ai: _ai)) return true;
+      if (widget.filter != null && !widget.filter!(element.illusts!)) {
+        return true;
+      }
+      return false;
+    });
     return SliverChildBuilderDelegate((BuildContext context, int index) {
       return IllustCard(
         lightingStore: _store,


### PR DESCRIPTION
## **核心变更**
- **新增动图筛选功能**：
    - 在搜索结果页面引入了 `UgoiraFilter` 枚举，支持“全部”、“仅动图”以及“不含动图”三种过滤模式。
    - 在 `LightingList` 组件中新增了自定义过滤器回调（`filter` 参数），实现在客户端对插画列表进行实时过滤。
- **优化筛选状态管理**：
    - 修复了之前筛选面板在关闭时会意外同步未确认状态的问题（Issue #1120）。现在仅在点击“应用”时才会更新并保存筛选配置。(不一起做会导致逻辑不协调)
    - 支持持久化存储用户的动图筛选偏好。
- **多语言支持**：
    - 更新了 `intl_zh_CN`、`intl_en`、`intl_ja` 等语言文件，新增了动图筛选相关的本地化文本。

## **技术细节**
- **UI 整合**：将动图过滤器整合至搜索结果的排序底部面板（`ResultIllustSortWidget`），采用响应式布局。
- **逻辑实现**：利用 Dart 3 的 `switch` 表达式简化了 `UgoiraFilter` 的逻辑判断，提高了代码可读性。
- **数据流**：筛选器状态通过 `onSateChange` 回调在面板与主页面间传递，确保了 UI 状态的一致性与逻辑解耦。

> 我換了個分支所以 #1121 就 Close了

## **关联 Issue**
- Fixes #1120