### PR TITLE
完善了一些缺失的本地化翻译

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -331,5 +331,7 @@
   "start_follow": "Folgen starten",
   "news_follow_title": "Gefolgt",
   "user_page_info_title": "Nutzerinfo",
-  "input_regexp_hint": "Tag-Namen oder regulären Ausdruck eingeben"
+  "input_regexp_hint": "Tag-Namen oder regulären Ausdruck eingeben",
+  "ugoira_only": "Nur Ugoira",
+  "ugoira_none": "Keine Ugoira"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -332,5 +332,6 @@
   "cancel_follow": "Cancel follow",
   "start_follow": "Start follow",
   "news_follow_title": "Following",
-  "user_page_info_title": "User info"
+  "user_page_info_title": "User info",
+  "input_regexp_hint": "Enter regexp"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -320,5 +320,9 @@
   "start_follow": "Start follow",
   "news_follow_title": "Siguiente",
   "user_page_info_title": "Información de usuario",
-  "input_regexp_hint": "Ingrese el nombre de la etiqueta o expresión regular"
+  "input_regexp_hint": "Ingrese el nombre de la etiqueta o expresión regular",
+  "ugoira_only": "Solo Ugoira",
+  "ugoira_none": "Sin Ugoira",
+  "popular_male_desc": "Popular entre los hombres",
+  "popular_female_desc": "Popular entre las mujeres"
 }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -329,5 +329,9 @@
   "start_follow": "Simulan ang pagsundan",
   "news_follow_title": "Sinusundan",
   "user_page_info_title": "Impormasyon ng user",
-  "input_regexp_hint": "Maglagay ng mga keyword o pangalan tulad ng"
+  "input_regexp_hint": "Maglagay ng mga keyword o pangalan tulad ng",
+  "ugoira_only": "Ugoira lang",
+  "ugoira_none": "Walang Ugoira",
+  "export_novel_history": "I-export ang history ng novel",
+  "import_novel_history": "I-import ang history ng novel"
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -329,6 +329,9 @@
     "start_follow": "Ikuti",
     "news_follow_title": "Mengikuti",
     "user_page_info_title": "Informasi pengguna",
-    "input_regexp_hint": "Masukkan nama tag atau ekspresi reguler"
-  }
-  
+    "input_regexp_hint": "Masukkan nama tag atau ekspresi reguler",
+    "ugoira_only": "Hanya Ugoira",
+    "ugoira_none": "Tanpa Ugoira",
+    "popular_male_desc": "Populer di kalangan pria",
+    "popular_female_desc": "Populer di kalangan wanita"
+}

--- a/lib/l10n/intl_id_ID.arb
+++ b/lib/l10n/intl_id_ID.arb
@@ -329,5 +329,9 @@
   "start_follow": "Ikuti",
   "news_follow_title": "Mengikuti",
   "user_page_info_title": "Informasi pengguna",
-  "input_regexp_hint": "Masukkan nama tag atau ekspresi reguler"
+  "input_regexp_hint": "Masukkan nama tag atau ekspresi reguler",
+  "ugoira_only": "Hanya Ugoira",
+  "ugoira_none": "Tanpa Ugoira",
+  "popular_male_desc": "Populer di kalangan pria",
+  "popular_female_desc": "Populer di kalangan wanita"
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -331,5 +331,7 @@
   "start_follow": "Start follow",
   "news_follow_title": "フォロー中",
   "user_page_info_title": "ユーザー情報",
-  "input_regexp_hint": "タグ名または正規表現を入力"
+  "input_regexp_hint": "タグ名または正規表現を入力",
+  "popular_male_desc": "男性に人気",
+  "popular_female_desc": "女性に人気"
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -329,5 +329,9 @@
   "start_follow": "Start follow",
   "news_follow_title": "팔로우 중",
   "user_page_info_title": "유저 정보",
-  "input_regexp_hint": "태그 이름 또는 정규식을 입력하세요"
+  "input_regexp_hint": "태그 이름 또는 정규식을 입력하세요",
+  "ugoira_only": "우고이라만",
+  "ugoira_none": "우고이라 없음",
+  "popular_male_desc": "남성 인기 순",
+  "popular_female_desc": "여성 인기 순"
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -329,5 +329,9 @@
   "start_follow": "Подписаться",
   "news_follow_title": "Подписки на пользователей",
   "user_page_info_title": "Информация",
-  "input_regexp_hint": "Введите название метки или регулярное выражение"
+  "input_regexp_hint": "Введите название метки или регулярное выражение",
+  "ugoira_only": "Только Ugoira",
+  "ugoira_none": "Без Ugoira",
+  "popular_male_desc": "Популярно у мужчин",
+  "popular_female_desc": "Популярно у женщин"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -329,5 +329,9 @@
   "start_follow": "Takip etmeye başla",
    "news_follow_title": "Takip et",
   "user_page_info_title": "Kullanıcı bilgileri",
-  "input_regexp_hint": "Etiket adı veya düzenli ifade girin"
+  "input_regexp_hint": "Etiket adı veya düzenli ifade girin",
+  "ugoira_only": "Sadece Ugoira",
+  "ugoira_none": "Ugoira Olmayanlar",
+  "popular_male_desc": "Erkekler arasında popüler",
+  "popular_female_desc": "Kadınlar arasında popüler"
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -331,5 +331,7 @@
   "start_follow": "Bắt đầu theo dõi",
   "news_follow_title": "Đang theo dõi",
   "user_page_info_title": "Thông tin người dùng",
-  "input_regexp_hint": "Nhập tag name hoặc biểu thức regex"
+  "input_regexp_hint": "Nhập tag name hoặc biểu thức regex",
+  "ugoira_only": "Chỉ Ugoira",
+  "ugoira_none": "Không có Ugoira"
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -331,5 +331,7 @@
   "start_follow": "Bắt đầu theo dõi",
   "news_follow_title": "Đang theo dõi",
   "user_page_info_title": "Thông tin người dùng",
-  "input_regexp_hint": "Nhập tag name hoặc biểu thức regex"
+  "input_regexp_hint": "Nhập tag name hoặc biểu thức regex",
+  "ugoira_only": "Chỉ Ugoira",
+  "ugoira_none": "Không có Ugoira"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -332,5 +332,6 @@
   "cancel_follow": "取消关注",
   "start_follow": "开始关注",
   "news_follow_title": "已关注",
-  "user_page_info_title": "详情"
+  "user_page_info_title": "详情",
+  "input_regexp_hint": "输入正则表达式"
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -331,5 +331,7 @@
   "start_follow": "開始關注",
   "news_follow_title": "已關注",
   "user_page_info_title": "資訊",
-  "input_regexp_hint": "輸入標籤名或正則表達式"
+  "input_regexp_hint": "輸入標籤名或正則表達式",
+  "popular_male_desc": "在男性中受歡迎",
+  "popular_female_desc": "在女性中受歡迎"
 }


### PR DESCRIPTION
完善了一些缺失的本地化翻译。
其中德语、西班牙语、菲律宾语、印地语、土耳其语使用了 AI 翻译。