### PR TITLE
Feat/bookmark search

### DIFF
--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -334,5 +334,33 @@
   "news_follow_title": "Following",
   "user_page_info_title": "User info",
   "input_regexp_hint": "Enter tag name or regular expression",
-  "automatically_tag_when_bookmarking": "Automatically tag when bookmarking"
+  "automatically_tag_when_bookmarking": "Automatically tag when bookmarking",
+  "bookmarkSearchTagEmpty": "Tag cannot be empty",
+  "bookmarkSearchTagExists": "This tag already exists",
+  "bookmarkSearchTagInputHint": "Input keywords",
+  "bookmarkAutoRequestInterval": "Bookmark auto request interval",
+  "bookmarkAutoRequestIntervalHelper": "Set the delay between automatic bookmark requests in milliseconds.",
+  "bookmarkAutoRequestIntervalInvalid": "Please enter an integer greater than 0.",
+  "bookmarkAutoRequestIntervalWarningTitle": "Warning",
+  "bookmarkAutoRequestIntervalWarning": "Request intervals below 700 ms are likely to trigger rate limiting.",
+  "bookmarkAutoRequestIntervalValue": "Current: {value} ms",
+  "@bookmarkAutoRequestIntervalValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "bookmarkDeepSearchStats": "Continuous searching (Matched: {matchedCount} / Total: {fetchedCount})",
+  "@bookmarkDeepSearchStats": {
+    "placeholders": {
+      "matchedCount": {
+        "type": "String"
+      },
+      "fetchedCount": {
+        "type": "String"
+      }
+    }
+  },
+  "continuousRequesting": "Loading continuously"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -333,5 +333,34 @@
   "start_follow": "开始关注",
   "news_follow_title": "已关注",
   "user_page_info_title": "详情",
-  "input_regexp_hint": "输入正则表达式"
+  "input_regexp_hint": "输入正则表达式",
+  "automatically_tag_when_bookmarking": "收藏时自动添加标签",
+  "bookmarkSearchTagEmpty": "标签不能为空",
+  "bookmarkSearchTagExists": "该标签已存在",
+  "bookmarkSearchTagInputHint": "输入关键字",
+  "bookmarkAutoRequestInterval": "收藏自动请求间隔",
+  "bookmarkAutoRequestIntervalHelper": "设置收藏持续搜索时每次自动请求之间的间隔，单位为毫秒。",
+  "bookmarkAutoRequestIntervalInvalid": "请输入大于 0 的整数。",
+  "bookmarkAutoRequestIntervalWarningTitle": "警告",
+  "bookmarkAutoRequestIntervalWarning": "700ms 以下的请求间隔容易触发风控。",
+  "bookmarkAutoRequestIntervalValue": "当前：{value} ms",
+  "@bookmarkAutoRequestIntervalValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "bookmarkDeepSearchStats": "持续搜索 (命中: {matchedCount} / 总数: {fetchedCount})",
+  "@bookmarkDeepSearchStats": {
+    "placeholders": {
+      "matchedCount": {
+        "type": "String"
+      },
+      "fetchedCount": {
+        "type": "String"
+      }
+    }
+  },
+  "continuousRequesting": "正在持续请求"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -334,5 +334,33 @@
   "news_follow_title": "已关注",
   "user_page_info_title": "详情",
   "input_regexp_hint": "输入标签名或正则表达式",
-  "automatically_tag_when_bookmarking": "收藏时自动添加标签"
+  "automatically_tag_when_bookmarking": "收藏时自动添加标签",
+  "bookmarkSearchTagEmpty": "标签不能为空",
+  "bookmarkSearchTagExists": "该标签已存在",
+  "bookmarkSearchTagInputHint": "输入关键字",
+  "bookmarkAutoRequestInterval": "收藏自动请求间隔",
+  "bookmarkAutoRequestIntervalHelper": "设置收藏持续搜索时每次自动请求之间的间隔，单位为毫秒。",
+  "bookmarkAutoRequestIntervalInvalid": "请输入大于 0 的整数。",
+  "bookmarkAutoRequestIntervalWarningTitle": "警告",
+  "bookmarkAutoRequestIntervalWarning": "700ms 以下的请求间隔容易触发风控。",
+  "bookmarkAutoRequestIntervalValue": "当前：{value} ms",
+  "@bookmarkAutoRequestIntervalValue": {
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "bookmarkDeepSearchStats": "持续搜索 (命中: {matchedCount} / 总数: {fetchedCount})",
+  "@bookmarkDeepSearchStats": {
+    "placeholders": {
+      "matchedCount": {
+        "type": "String"
+      },
+      "fetchedCount": {
+        "type": "String"
+      }
+    }
+  },
+  "continuousRequesting": "正在持续请求"
 }

--- a/lib/lighting/lighting_page.dart
+++ b/lib/lighting/lighting_page.dart
@@ -19,7 +19,6 @@ import 'dart:math';
 import 'package:easy_refresh/easy_refresh.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
-import 'package:mobx/mobx.dart';
 import 'package:pixez/component/illust_card.dart';
 import 'package:pixez/component/pixez_default_header.dart';
 import 'package:pixez/exts.dart';
@@ -70,6 +69,28 @@ class _ContinuousRequestFooter extends NotLoadFooter {
   }
 }
 
+class LightingListController extends ChangeNotifier {
+  LightingStore? _store;
+
+  LightingStore? get store => _store;
+
+  void _attach(LightingStore store) {
+    if (identical(_store, store)) {
+      return;
+    }
+    _store = store;
+    notifyListeners();
+  }
+
+  void _detach(LightingStore store) {
+    if (!identical(_store, store)) {
+      return;
+    }
+    _store = null;
+    notifyListeners();
+  }
+}
+
 class LightingList extends StatefulWidget {
   final LightSource source;
   final Widget? header;
@@ -78,8 +99,7 @@ class LightingList extends StatefulWidget {
   final String? portal;
   final bool? ai;
   final bool Function(Illusts)? filter;
-  final Function(LightingStore)? onStoreCreated;
-  final ValueChanged<LightingStore>? onStoreChanged;
+  final LightingListController? controller;
   final bool enableRefresh;
   final bool enableLoad;
   final bool showContinuousLoadHint;
@@ -93,8 +113,7 @@ class LightingList extends StatefulWidget {
     this.portal,
     this.ai,
     this.filter,
-    this.onStoreCreated,
-    this.onStoreChanged,
+    this.controller,
     this.enableRefresh = true,
     this.enableLoad = true,
     this.showContinuousLoadHint = false,
@@ -113,12 +132,13 @@ class _LightingListState extends State<LightingList> {
   @override
   void didUpdateWidget(LightingList oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?._detach(_store);
+      widget.controller?._attach(_store);
+    }
     if (oldWidget.source != widget.source) {
       _store.source = widget.source;
       _fetch();
-    }
-    if (oldWidget.onStoreChanged != widget.onStoreChanged) {
-      widget.onStoreChanged?.call(_store);
     }
   }
 
@@ -131,8 +151,6 @@ class _LightingListState extends State<LightingList> {
       _scrollController.position.jumpTo(0.0);
     }
   }
-
-  ReactionDisposer? disposer;
 
   void _updateBackToTopVisible(bool atEdge) {
     // Back-to-top is not implemented yet. Ignore scroll-driven state changes.
@@ -149,21 +167,15 @@ class _LightingListState extends State<LightingList> {
     );
     _store = LightingStore(widget.source);
     _store.easyRefreshController = _refreshController;
-    // Expose the internal store immediately so parents like BookmarkPage can
-    // coordinate filtering, stats and continuous paging state.
-    widget.onStoreCreated?.call(_store);
-    disposer = reaction<int>((_) => _store.iStores.length, (_) {
-      // Notify on list growth so parent widgets can refresh derived counters
-      // without reaching into LightingStore's own reactions.
-      widget.onStoreChanged?.call(_store);
-    });
+    // Expose the internal store through a controller so callers can access the store instance
+    widget.controller?._attach(_store);
     super.initState();
     _store.fetch();
   }
 
   @override
   void dispose() {
-    disposer?.call();
+    widget.controller?._detach(_store);
     if (widget.scrollController == null) {
       _scrollController.dispose();
     }

--- a/lib/lighting/lighting_page.dart
+++ b/lib/lighting/lighting_page.dart
@@ -39,8 +39,33 @@ class WaterFallLoading extends StatefulWidget {
 class _WaterFallLoadingState extends State<WaterFallLoading> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Center(child: CircularProgressIndicator()),
+    return Container(child: Center(child: CircularProgressIndicator()));
+  }
+}
+
+class _ContinuousRequestFooter extends NotLoadFooter {
+  const _ContinuousRequestFooter({super.position = IndicatorPosition.above});
+
+  @override
+  Widget build(BuildContext context, IndicatorState state) {
+    // Reuse EasyRefresh's not-load slot to show that loading is intentionally
+    // being driven by BookmarkPage instead of by the footer trigger itself.
+    final color = Theme.of(context).textTheme.bodySmall?.color;
+    return SizedBox(
+      height: 52,
+      child: Center(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.sync, size: 16, color: color),
+            const SizedBox(width: 8),
+            Text(
+              I18n.of(context).continuousRequesting,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -53,17 +78,27 @@ class LightingList extends StatefulWidget {
   final String? portal;
   final bool? ai;
   final bool Function(Illusts)? filter;
+  final Function(LightingStore)? onStoreCreated;
+  final ValueChanged<LightingStore>? onStoreChanged;
+  final bool enableRefresh;
+  final bool enableLoad;
+  final bool showContinuousLoadHint;
 
-  const LightingList(
-      {Key? key,
-      required this.source,
-      this.header,
-      this.isNested,
-      this.scrollController,
-      this.portal,
-      this.ai,
-      this.filter})
-      : super(key: key);
+  const LightingList({
+    Key? key,
+    required this.source,
+    this.header,
+    this.isNested,
+    this.scrollController,
+    this.portal,
+    this.ai,
+    this.filter,
+    this.onStoreCreated,
+    this.onStoreChanged,
+    this.enableRefresh = true,
+    this.enableLoad = true,
+    this.showContinuousLoadHint = false,
+  }) : super(key: key);
 
   @override
   _LightingListState createState() => _LightingListState();
@@ -82,6 +117,9 @@ class _LightingListState extends State<LightingList> {
       _store.source = widget.source;
       _fetch();
     }
+    if (oldWidget.onStoreChanged != widget.onStoreChanged) {
+      widget.onStoreChanged?.call(_store);
+    }
   }
 
   _fetch() async {
@@ -96,23 +134,36 @@ class _LightingListState extends State<LightingList> {
 
   ReactionDisposer? disposer;
 
+  void _updateBackToTopVisible(bool atEdge) {
+    // Back-to-top is not implemented yet. Ignore scroll-driven state changes.
+  }
+
   @override
   void initState() {
     _ai = widget.ai ?? false;
     _isNested = widget.isNested ?? false;
     _scrollController = widget.scrollController ?? ScrollController();
     _refreshController = EasyRefreshController(
-        controlFinishLoad: true, controlFinishRefresh: true);
-    _store = LightingStore(
-      widget.source,
+      controlFinishLoad: true,
+      controlFinishRefresh: true,
     );
+    _store = LightingStore(widget.source);
     _store.easyRefreshController = _refreshController;
+    // Expose the internal store immediately so parents like BookmarkPage can
+    // coordinate filtering, stats and continuous paging state.
+    widget.onStoreCreated?.call(_store);
+    disposer = reaction<int>((_) => _store.iStores.length, (_) {
+      // Notify on list growth so parent widgets can refresh derived counters
+      // without reaching into LightingStore's own reactions.
+      widget.onStoreChanged?.call(_store);
+    });
     super.initState();
     _store.fetch();
   }
 
   @override
   void dispose() {
+    disposer?.call();
     if (widget.scrollController == null) {
       _scrollController.dispose();
     }
@@ -121,62 +172,69 @@ class _LightingListState extends State<LightingList> {
     super.dispose();
   }
 
-  bool backToTopVisible = false;
-
   @override
   Widget build(BuildContext context) {
     return Container(
-      child: Observer(builder: (_) {
-        return Container(child: _buildContent(context));
-      }),
+      child: Observer(
+        builder: (_) {
+          return Container(child: _buildContent(context));
+        },
+      ),
     );
   }
 
   late EasyRefreshController _refreshController;
 
   Widget _buildWithoutHeader(context) {
-    _store.iStores.removeWhere((element) {
-      if (element.illusts!.hateByUser(ai: _ai)) return true;
+    final filteredStores = _store.iStores.where((element) {
+      if (element.illusts!.hateByUser(ai: _ai)) return false;
       if (widget.filter != null && !widget.filter!(element.illusts!)) {
-        return true;
+        return false;
       }
-      return false;
-    });
+      return true;
+    }).toList();
     return NotificationListener<ScrollNotification>(
-        onNotification: (ScrollNotification notification) {
-          if (widget.isNested == true) {
-            return true;
-          }
-          ScrollMetrics metrics = notification.metrics;
-          if (backToTopVisible == metrics.atEdge && mounted) {
-            setState(() {
-              backToTopVisible = !backToTopVisible;
-            });
-          }
+      onNotification: (ScrollNotification notification) {
+        if (widget.isNested == true) {
           return true;
-        },
-        child: EasyRefresh.builder(
-          controller: _refreshController,
-          header: PixezDefault.header(context),
-          footer: PixezDefault.footer(context),
-          scrollController: _scrollController,
-          onRefresh: () {
-            _store.fetch(force: true);
+        }
+        _updateBackToTopVisible(notification.metrics.atEdge);
+        return true;
+      },
+      child: EasyRefresh.builder(
+        controller: _refreshController,
+        header: PixezDefault.header(context),
+        footer: PixezDefault.footer(context),
+        notLoadFooter: widget.showContinuousLoadHint
+            ? const _ContinuousRequestFooter()
+            : null,
+        scrollController: _scrollController,
+        onRefresh: widget.enableRefresh
+            ? () {
+                _store.fetch(force: true);
+              }
+            : null,
+        onLoad: widget.enableLoad
+            ? () {
+                _store.fetchNext();
+              }
+            : null,
+        childBuilder: (context, physics) => WaterfallFlow.builder(
+          physics: physics,
+          controller: widget.isNested ?? false ? null : _scrollController,
+          padding: EdgeInsets.all(5.0),
+          itemCount: filteredStores.length,
+          itemBuilder: (context, index) {
+            return IllustCard(
+              store: filteredStores[index],
+              lightingStore: _store,
+              iStores: _store.iStores,
+            );
           },
-          onLoad: () {
-            _store.fetchNext();
-          },
-          childBuilder: (context, physics) => WaterfallFlow.builder(
-            physics: physics,
-            controller: widget.isNested ?? false ? null : _scrollController,
-            padding: EdgeInsets.all(5.0),
-            itemCount: _store.iStores.length,
-            itemBuilder: (context, index) {
-              return _buildItem(index);
-            },
-            gridDelegate: _buildGridDelegate(),
-          ),
-        ));
+          gridDelegate: _buildGridDelegate(),
+        ),
+      ),
+    );
   }
 
   bool needToBan(Illusts illust) {
@@ -198,12 +256,12 @@ class _LightingListState extends State<LightingList> {
     return _store.errorMessage != null
         ? _buildErrorContent(context)
         : _store.iStores.isNotEmpty
-            ? (widget.header != null
-                ? _buildWithHeader(context)
-                : _buildWithoutHeader(context))
-            : Container(
-                child: _store.refreshing ? WaterFallLoading() : Container(),
-              );
+        ? (widget.header != null
+              ? _buildWithHeader(context)
+              : _buildWithoutHeader(context))
+        : Container(
+            child: _store.refreshing ? WaterFallLoading() : Container(),
+          );
   }
 
   Widget _buildErrorContent(context) {
@@ -241,26 +299,32 @@ class _LightingListState extends State<LightingList> {
   Widget _buildWithHeader(BuildContext context) {
     return NotificationListener<ScrollNotification>(
       onNotification: (ScrollNotification notification) {
-        ScrollMetrics metrics = notification.metrics;
-        if (backToTopVisible == metrics.atEdge && mounted) {
-          setState(() {
-            backToTopVisible = !backToTopVisible;
-          });
-        }
+        _updateBackToTopVisible(notification.metrics.atEdge);
         return true;
       },
       child: EasyRefresh.builder(
         controller: _refreshController,
         scrollController: _scrollController,
         header: PixezDefault.header(context),
-        footer:
-            PixezDefault.footer(context, position: IndicatorPosition.locator),
-        onRefresh: () {
-          _store.fetch(force: true);
-        },
-        onLoad: () {
-          _store.fetchNext();
-        },
+        footer: PixezDefault.footer(
+          context,
+          position: IndicatorPosition.locator,
+        ),
+        notLoadFooter: widget.showContinuousLoadHint
+            ? const _ContinuousRequestFooter(
+                position: IndicatorPosition.locator,
+              )
+            : null,
+        onRefresh: widget.enableRefresh
+            ? () {
+                _store.fetch(force: true);
+              }
+            : null,
+        onLoad: widget.enableLoad
+            ? () {
+                _store.fetchNext();
+              }
+            : null,
         childBuilder: ((context, physics) {
           return CustomScrollView(
             physics: physics,
@@ -282,21 +346,22 @@ class _LightingListState extends State<LightingList> {
   }
 
   SliverChildBuilderDelegate _buildSliverChildBuilderDelegate(
-      BuildContext context) {
-    _store.iStores.removeWhere((element) {
-      if (element.illusts!.hateByUser(ai: _ai)) return true;
+    BuildContext context,
+  ) {
+    final filteredStores = _store.iStores.where((element) {
+      if (element.illusts!.hateByUser(ai: _ai)) return false;
       if (widget.filter != null && !widget.filter!(element.illusts!)) {
-        return true;
+        return false;
       }
-      return false;
-    });
+      return true;
+    }).toList();
     return SliverChildBuilderDelegate((BuildContext context, int index) {
       return IllustCard(
         lightingStore: _store,
-        store: _store.iStores[index],
+        store: filteredStores[index],
         iStores: _store.iStores,
       );
-    }, childCount: _store.iStores.length);
+    }, childCount: filteredStores.length);
   }
 
   SliverWaterfallFlowDelegate _buildGridDelegate() {

--- a/lib/page/hello/setting/bookmark_auto_request_interval_page.dart
+++ b/lib/page/hello/setting/bookmark_auto_request_interval_page.dart
@@ -1,0 +1,103 @@
+import 'package:bot_toast/bot_toast.dart';
+import 'package:flutter/material.dart';
+import 'package:pixez/i18n.dart';
+import 'package:pixez/main.dart';
+
+class BookmarkAutoRequestIntervalPage extends StatefulWidget {
+  const BookmarkAutoRequestIntervalPage({Key? key}) : super(key: key);
+
+  @override
+  State<BookmarkAutoRequestIntervalPage> createState() =>
+      _BookmarkAutoRequestIntervalPageState();
+}
+
+class _BookmarkAutoRequestIntervalPageState
+    extends State<BookmarkAutoRequestIntervalPage> {
+  late TextEditingController _textEditingController;
+
+  @override
+  void initState() {
+    super.initState();
+    _textEditingController = TextEditingController(
+      text: userSetting.bookmarkAutoRequestInterval.toString(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _textEditingController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _resetToDefault() async {
+    _textEditingController.text = '500';
+    await userSetting.setBookmarkAutoRequestInterval(500);
+  }
+
+  Future<void> _save() async {
+    final value = int.tryParse(_textEditingController.text.trim());
+    if (value == null || value <= 0) {
+      BotToast.showText(
+        text: I18n.of(context).bookmarkAutoRequestIntervalInvalid,
+      );
+      return;
+    }
+    await userSetting.setBookmarkAutoRequestInterval(value);
+    if (!mounted) {
+      return;
+    }
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(I18n.of(context).bookmarkAutoRequestInterval),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _resetToDefault,
+          ),
+          IconButton(icon: const Icon(Icons.save), onPressed: _save),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(12.0),
+        children: [
+          TextField(
+            controller: _textEditingController,
+            keyboardType: TextInputType.number,
+            decoration: InputDecoration(
+              border: const OutlineInputBorder(),
+              labelText: I18n.of(context).bookmarkAutoRequestInterval,
+              helperText: I18n.of(context).bookmarkAutoRequestIntervalHelper,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            color: Theme.of(context).colorScheme.errorContainer,
+            child: ListTile(
+              leading: Icon(
+                Icons.warning_amber_rounded,
+                color: Theme.of(context).colorScheme.onErrorContainer,
+              ),
+              title: Text(
+                I18n.of(context).bookmarkAutoRequestIntervalWarningTitle,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onErrorContainer,
+                ),
+              ),
+              subtitle: Text(
+                I18n.of(context).bookmarkAutoRequestIntervalWarning,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/page/hello/setting/bookmark_auto_request_interval_page.dart
+++ b/lib/page/hello/setting/bookmark_auto_request_interval_page.dart
@@ -30,8 +30,8 @@ class _BookmarkAutoRequestIntervalPageState
   }
 
   Future<void> _resetToDefault() async {
-    _textEditingController.text = '500';
-    await userSetting.setBookmarkAutoRequestInterval(500);
+    _textEditingController.text = '700';
+    await userSetting.setBookmarkAutoRequestInterval(700);
   }
 
   Future<void> _save() async {

--- a/lib/page/hello/setting/setting_quality_page.dart
+++ b/lib/page/hello/setting/setting_quality_page.dart
@@ -26,6 +26,7 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/glance_illust_persist.dart';
 import 'package:pixez/page/about/languages.dart';
+import 'package:pixez/page/hello/setting/bookmark_auto_request_interval_page.dart';
 import 'package:pixez/page/hello/setting/copy_text_page.dart';
 import 'package:pixez/page/hello/setting/setting_cross_adapter_page.dart';
 import 'package:pixez/page/network/network_page.dart';
@@ -102,6 +103,25 @@ class _SettingQualityPageState extends State<SettingQualityPage>
               title: Text(I18n.of(context).share_info_format),
               trailing: const Icon(Icons.arrow_right),
               onTap: () => Leader.push(context, CopyTextPage()),
+            ),
+            ListTile(
+                  leading: const Icon(Icons.timer_outlined),
+                  title: Text(I18n.of(context).bookmarkAutoRequestInterval),
+                  subtitle: Text(
+                    I18n.of(context).bookmarkAutoRequestIntervalValue(
+                      userSetting.bookmarkAutoRequestInterval.toString(),
+                    ),
+                  ),
+                  trailing: const Icon(Icons.arrow_right),
+                  onTap: () async {
+                    await Leader.push(
+                      context,
+                      const BookmarkAutoRequestIntervalPage(),
+                    );
+                    if (mounted) {
+                      setState(() {});
+                    }
+                  },
             ),
             _buildLanguageSelect(),
             Divider(),

--- a/lib/page/search/suggest/suggestion_store.dart
+++ b/lib/page/search/suggest/suggestion_store.dart
@@ -22,13 +22,30 @@ part 'suggestion_store.g.dart';
 class SuggestionStore = _SuggestionStoreBase with _$SuggestionStore;
 
 abstract class _SuggestionStoreBase with Store {
+  int _requestVersion = 0;
+
   @observable
   AutoWords? autoWords;
-  fetch(String query) async {
+
+  void clear() {
+    _requestVersion++;
+    autoWords = null;
+  }
+
+  Future<void> fetch(String query) async {
+    final requestVersion = ++_requestVersion;
     try {
-      AutoWords autoWords =
+      final AutoWords autoWords =
           await apiClient.getSearchAutoCompleteKeywords(query);
+      if (requestVersion != _requestVersion) {
+        return;
+      }
       this.autoWords = autoWords;
-    } catch (e) {}
+    } catch (_) {
+      if (requestVersion != _requestVersion) {
+        return;
+      }
+      autoWords = null;
+    }
   }
 }

--- a/lib/page/user/bookmark/bookmark_page.dart
+++ b/lib/page/user/bookmark/bookmark_page.dart
@@ -57,6 +57,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
 
   late LightSource futureGet;
   String restrict = 'public';
+  late LightingListController _lightingController;
   late ScrollController _scrollController;
   late StreamSubscription<String> subscription;
   String? currentTag;
@@ -68,7 +69,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
   List<String> _searchTags = [];
 
   // a ref of the inner lightingStore
-  LightingStore? _lightingStore;
+  LightingStore? get _lightingStore => _lightingController.store;
 
   // is in continuous auto fetching state
   bool _isDeepSearching = false;
@@ -76,26 +77,8 @@ class _BookmarkPageState extends State<BookmarkPage> {
   // performing a fetch
   bool _isDeepSearchLoading = false;
 
-  // ref to the the ongoing fetch 
+  // ref to the the ongoing fetch
   Future<void>? _deepSearchTask;
-
-  void _bindLightingStore(LightingStore store) {
-    // Keep the latest LightingStore so bookmark search and continuous loading
-    // controls can observe the list state managed inside LightingList.
-    _lightingStore = store;
-  }
-
-  void _handleStoreChanged(LightingStore store) {
-    _lightingStore = store;
-    if (!mounted) {
-      return;
-    }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        setState(() {});
-      }
-    });
-  }
 
   void _startDeepSearch() {
     if (_lightingStore == null || _isDeepSearching) return;
@@ -201,8 +184,9 @@ class _BookmarkPageState extends State<BookmarkPage> {
     });
   }
 
+  // iStores is a mobx observable 
+  // these two value will be observed.
   int get _fetchedIllustCount => _lightingStore?.iStores.length ?? 0;
-
   int get _matchedIllustCount {
     final store = _lightingStore;
     if (store == null) {
@@ -215,6 +199,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
 
   @override
   void initState() {
+    _lightingController = LightingListController();
     _scrollController = ScrollController();
     restrict = widget.restrict;
     futureGet = ApiForceSource(
@@ -233,6 +218,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
     _isDeepSearching = false;
     _deepSearchTask = null;
     subscription.cancel();
+    _lightingController.dispose();
     _scrollController.dispose();
     super.dispose();
   }
@@ -255,8 +241,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
                 height: _showSearch ? 180 : 45,
               ),
               filter: _filterIllust,
-              onStoreCreated: _bindLightingStore,
-              onStoreChanged: _handleStoreChanged,
+              controller: _lightingController,
               enableRefresh: !_isDeepSearching,
               enableLoad: !_isDeepSearching,
               showContinuousLoadHint: _isDeepSearching,
@@ -270,8 +255,7 @@ class _BookmarkPageState extends State<BookmarkPage> {
         scrollController: _scrollController,
         source: futureGet,
         filter: _filterIllust,
-        onStoreCreated: _bindLightingStore,
-        onStoreChanged: _handleStoreChanged,
+        controller: _lightingController,
         enableRefresh: !_isDeepSearching,
         enableLoad: !_isDeepSearching,
         showContinuousLoadHint: _isDeepSearching,
@@ -344,18 +328,11 @@ class _BookmarkPageState extends State<BookmarkPage> {
               GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: () async {
-                  // if (_showSearch) {
-                  //   await _stopDeepSearch();
-                  // }
                   if (!mounted) {
                     return;
                   }
-                  // final isClosingSearch = _showSearch;
                   setState(() {
                     _showSearch = !_showSearch;
-                    // if (isClosingSearch) {
-                    //   _searchTags.clear();
-                    // }
                   });
                 },
                 child: Chip(
@@ -413,42 +390,57 @@ class _BookmarkPageState extends State<BookmarkPage> {
                               horizontal: 16.0,
                               vertical: 4.0,
                             ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Text(
-                                  I18n.of(context).bookmarkDeepSearchStats(
-                                    _matchedIllustCount.toString(),
-                                    _fetchedIllustCount.toString(),
-                                  ),
-                                  style: Theme.of(context).textTheme.bodySmall,
-                                ),
-                                Row(
-                                  children: [
-                                    if (_isDeepSearchLoading)
-                                      const Padding(
-                                        padding: EdgeInsets.only(right: 8.0),
-                                        child: SizedBox(
-                                          width: 16,
-                                          height: 16,
-                                          child: CircularProgressIndicator(
-                                            strokeWidth: 2,
+                            child: AnimatedBuilder(
+                              animation: _lightingController,
+                              builder: (_, __) {
+                                return Observer(
+                                  builder: (_) {
+                                    return Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        Text(
+                                          I18n.of(context).bookmarkDeepSearchStats(
+                                            _matchedIllustCount.toString(),
+                                            _fetchedIllustCount.toString(),
                                           ),
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .bodySmall,
                                         ),
-                                      ),
-                                    Switch(
-                                      value: _isDeepSearching,
-                                      onChanged: (val) async {
-                                        if (val) {
-                                          _startDeepSearch();
-                                        } else {
-                                          await _stopDeepSearch();
-                                        }
-                                      },
-                                    ),
-                                  ],
-                                ),
-                              ],
+                                        Row(
+                                          children: [
+                                            if (_isDeepSearchLoading)
+                                              const Padding(
+                                                padding: EdgeInsets.only(
+                                                  right: 8.0,
+                                                ),
+                                                child: SizedBox(
+                                                  width: 16,
+                                                  height: 16,
+                                                  child:
+                                                      CircularProgressIndicator(
+                                                    strokeWidth: 2,
+                                                  ),
+                                                ),
+                                              ),
+                                            Switch(
+                                              value: _isDeepSearching,
+                                              onChanged: (val) async {
+                                                if (val) {
+                                                  _startDeepSearch();
+                                                } else {
+                                                  await _stopDeepSearch();
+                                                }
+                                              },
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    );
+                                  },
+                                );
+                              },
                             ),
                           ),
                         ],

--- a/lib/page/user/bookmark/bookmark_page.dart
+++ b/lib/page/user/bookmark/bookmark_page.dart
@@ -28,7 +28,10 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/lighting/lighting_page.dart';
 import 'package:pixez/lighting/lighting_store.dart';
 import 'package:pixez/main.dart';
+import 'package:pixez/models/illust.dart';
 import 'package:pixez/network/api_client.dart';
+import 'package:pixez/page/user/bookmark/bookmark_search.dart'
+    show BookMarkSearchView;
 import 'package:pixez/page/user/bookmark/tag/user_bookmark_tag_page.dart';
 import 'package:pixez/page/user/works/works_page.dart';
 import 'package:waterfall_flow/waterfall_flow.dart';
@@ -50,11 +53,165 @@ class BookmarkPage extends StatefulWidget {
 }
 
 class _BookmarkPageState extends State<BookmarkPage> {
+  static const _searchCardAnimationDuration = Duration(milliseconds: 220);
+
   late LightSource futureGet;
   String restrict = 'public';
   late ScrollController _scrollController;
   late StreamSubscription<String> subscription;
   String? currentTag;
+
+  // toggle bookmark search card display
+  bool _showSearch = false;
+
+  // [BOOKMARK SEARCH MAIN STATE] current bookmark search tags
+  List<String> _searchTags = [];
+
+  // a ref of the inner lightingStore
+  LightingStore? _lightingStore;
+
+  // is in continuous auto fetching state
+  bool _isDeepSearching = false;
+
+  // performing a fetch
+  bool _isDeepSearchLoading = false;
+
+  // ref to the the ongoing fetch 
+  Future<void>? _deepSearchTask;
+
+  void _bindLightingStore(LightingStore store) {
+    // Keep the latest LightingStore so bookmark search and continuous loading
+    // controls can observe the list state managed inside LightingList.
+    _lightingStore = store;
+  }
+
+  void _handleStoreChanged(LightingStore store) {
+    _lightingStore = store;
+    if (!mounted) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  void _startDeepSearch() {
+    if (_lightingStore == null || _isDeepSearching) return;
+    setState(() {
+      _isDeepSearching = true;
+    });
+    _deepSearchTask = _runDeepSearch();
+  }
+
+  Future<void> _runDeepSearch() async {
+    // Continuous search keeps paging until the source runs out, the user stops
+    // it, or a page request fails.
+    while (_isDeepSearching &&
+        _lightingStore!.nextUrl != null &&
+        _lightingStore!.nextUrl!.isNotEmpty) {
+      if (!mounted) break;
+      setState(() {
+        _isDeepSearchLoading = true;
+      });
+      final success = await _lightingStore!.fetchNext();
+      if (!mounted) break;
+      setState(() {
+        _isDeepSearchLoading = false;
+      });
+
+      if (!success) {
+        setState(() {
+          _isDeepSearching = false;
+        });
+        break;
+      }
+
+      if (_isDeepSearching) {
+        // The request interval is user-configurable to balance speed and rate
+        // limiting risk during continuous bookmark scanning.
+        await Future.delayed(
+          Duration(milliseconds: userSetting.bookmarkAutoRequestInterval),
+        );
+      }
+    }
+
+    if (mounted) {
+      setState(() {
+        _isDeepSearching = false;
+        _isDeepSearchLoading = false;
+      });
+    }
+    _deepSearchTask = null;
+  }
+
+  Future<void> _stopDeepSearch() async {
+    if (_isDeepSearching && mounted) {
+      setState(() {
+        _isDeepSearching = false;
+      });
+    } else {
+      _isDeepSearching = false;
+    }
+    await _deepSearchTask;
+  }
+
+  Future<void> _switchBookmarkSource({
+    required String nextRestrict,
+    String? nextTag,
+  }) async {
+    // Source changes must stop the current continuous search first so old page
+    // requests do not continue against a stale bookmark query.
+    await _stopDeepSearch();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      restrict = nextRestrict;
+      currentTag = nextTag;
+      futureGet = ApiForceSource(
+        futureGet: (bool e) =>
+            apiClient.getBookmarksIllust(widget.id, nextRestrict, nextTag),
+      );
+    });
+  }
+
+  bool _filterIllust(Illusts illust) {
+    if (_searchTags.isEmpty) return true;
+    final normalizedTitle = illust.title.toLowerCase();
+
+    return _searchTags.every((searchTag) {
+      final keyword = searchTag.toLowerCase();
+      if (normalizedTitle.contains(keyword)) {
+        return true;
+      }
+
+      for (var tag in illust.tags) {
+        if (tag.name.toLowerCase().contains(keyword)) {
+          return true;
+        }
+        if (tag.translatedName != null &&
+            tag.translatedName!.toLowerCase().contains(keyword)) {
+          return true;
+        }
+      }
+
+      return false;
+    });
+  }
+
+  int get _fetchedIllustCount => _lightingStore?.iStores.length ?? 0;
+
+  int get _matchedIllustCount {
+    final store = _lightingStore;
+    if (store == null) {
+      return 0;
+    }
+    return store.iStores
+        .where((element) => _filterIllust(element.illusts!))
+        .length;
+  }
 
   @override
   void initState() {
@@ -73,6 +230,8 @@ class _BookmarkPageState extends State<BookmarkPage> {
 
   @override
   void dispose() {
+    _isDeepSearching = false;
+    _deepSearchTask = null;
     subscription.cancel();
     _scrollController.dispose();
     super.dispose();
@@ -88,7 +247,19 @@ class _BookmarkPageState extends State<BookmarkPage> {
               source: futureGet,
               scrollController: _scrollController,
               isNested: widget.isNested,
-              header: Container(height: 45),
+              // Reserve the search card's vertical space before the card itself
+              // fades/sizes in, which avoids the grid jumping abruptly.
+              header: AnimatedContainer(
+                duration: _searchCardAnimationDuration,
+                curve: Curves.easeOutCubic,
+                height: _showSearch ? 180 : 45,
+              ),
+              filter: _filterIllust,
+              onStoreCreated: _bindLightingStore,
+              onStoreChanged: _handleStoreChanged,
+              enableRefresh: !_isDeepSearching,
+              enableLoad: !_isDeepSearching,
+              showContinuousLoadHint: _isDeepSearching,
             ),
             buildTopChip(context),
           ],
@@ -98,6 +269,12 @@ class _BookmarkPageState extends State<BookmarkPage> {
         isNested: widget.isNested,
         scrollController: _scrollController,
         source: futureGet,
+        filter: _filterIllust,
+        onStoreCreated: _bindLightingStore,
+        onStoreChanged: _handleStoreChanged,
+        enableRefresh: !_isDeepSearching,
+        enableLoad: !_isDeepSearching,
+        showContinuousLoadHint: _isDeepSearching,
       );
     } else {
       return Container();
@@ -107,79 +284,178 @@ class _BookmarkPageState extends State<BookmarkPage> {
   Widget buildTopChip(BuildContext context) {
     return Align(
       alignment: Alignment.topCenter,
-      child: Row(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          SortGroup(
-            children: [I18n.of(context).public, I18n.of(context).private],
-            onChange: (index) {
-              if (index == 0)
-                setState(() {
-                  futureGet = ApiForceSource(
-                    futureGet: (bool e) => apiClient.getBookmarksIllust(
-                      widget.id,
-                      restrict = 'public',
-                      currentTag,
-                    ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SortGroup(
+                children: [I18n.of(context).public, I18n.of(context).private],
+                onChange: (index) async {
+                  await _switchBookmarkSource(
+                    nextRestrict: index == 0 ? 'public' : 'private',
+                    nextTag: currentTag,
                   );
-                });
-              if (index == 1)
-                setState(() {
-                  futureGet = ApiForceSource(
-                    futureGet: (bool e) => apiClient.getBookmarksIllust(
-                      widget.id,
-                      restrict = 'private',
-                      currentTag,
-                    ),
-                  );
-                });
-            },
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            child: GestureDetector(
-              onTap: () async {
-                final result = await Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (_) => UserBookmarkTagPage(currentTag: currentTag),
-                  ),
-                );
-                if (result != null) {
-                  String? tag = result['tag'];
-                  String restrict = result['restrict'];
-                  setState(() {
-                    currentTag = tag;
-                    futureGet = ApiForceSource(
-                      futureGet: (bool e) => apiClient.getBookmarksIllust(
-                        widget.id,
-                        restrict,
-                        tag,
+                },
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: GestureDetector(
+                  onTap: () async {
+                    await _stopDeepSearch();
+                    final result = await Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) =>
+                            UserBookmarkTagPage(currentTag: currentTag),
                       ),
                     );
-                  });
-                }
-              },
-              behavior: HitTestBehavior.opaque,
-              child: Chip(
-                label: Row(
-                  children: [
-                    Icon(Icons.tag, size: 18),
-                    if (currentTag != null)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 8.0),
-                        child: Text(
-                          currentTag!,
-                          style: Theme.of(context).textTheme.bodySmall,
-                        ),
-                      ),
-                  ],
+                    if (result != null) {
+                      String? tag = result['tag'];
+                      String restrict = result['restrict'];
+                      await _switchBookmarkSource(
+                        nextRestrict: restrict,
+                        nextTag: tag,
+                      );
+                    }
+                  },
+                  behavior: HitTestBehavior.opaque,
+                  child: Chip(
+                    label: Row(
+                      children: [
+                        Icon(Icons.tag, size: 18),
+                        if (currentTag != null)
+                          Padding(
+                            padding: const EdgeInsets.only(left: 8.0),
+                            child: Text(
+                              currentTag!,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ),
+                      ],
+                    ),
+                    backgroundColor: Theme.of(context).cardColor,
+                    elevation: 4.0,
+                    padding: EdgeInsets.all(0.0),
+                  ),
                 ),
-                backgroundColor: Theme.of(context).cardColor,
-                elevation: 4.0,
-                padding: EdgeInsets.all(0.0),
               ),
-            ),
+              GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () async {
+                  // if (_showSearch) {
+                  //   await _stopDeepSearch();
+                  // }
+                  if (!mounted) {
+                    return;
+                  }
+                  // final isClosingSearch = _showSearch;
+                  setState(() {
+                    _showSearch = !_showSearch;
+                    // if (isClosingSearch) {
+                    //   _searchTags.clear();
+                    // }
+                  });
+                },
+                child: Chip(
+                  label: Icon(
+                    _showSearch ? Icons.search_off : Icons.search,
+                    color:
+                        Theme.of(context).textTheme.bodySmall?.color ??
+                        Colors.grey,
+                    size: 18,
+                  ),
+                  backgroundColor: Theme.of(context).cardColor,
+                  elevation: 4.0,
+                  padding: EdgeInsets.all(0.0),
+                ),
+              ),
+            ],
+          ),
+          AnimatedSwitcher(
+            duration: _searchCardAnimationDuration,
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeInCubic,
+            transitionBuilder: (child, animation) {
+              // Fade + vertical size keeps the search panel expansion feeling
+              // lightweight while matching the reserved header height above.
+              return FadeTransition(
+                opacity: animation,
+                child: SizeTransition(
+                  sizeFactor: animation,
+                  axisAlignment: -1,
+                  child: child,
+                ),
+              );
+            },
+            child: _showSearch
+                ? Padding(
+                    key: const ValueKey('bookmark-search-card'),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0,
+                      vertical: 8.0,
+                    ),
+                    child: Card(
+                      child: Column(
+                        children: [
+                          BookMarkSearchView(
+                            tags: _searchTags,
+                            onChange: (tags) {
+                              setState(() {
+                                _searchTags = tags;
+                              });
+                            },
+                          ),
+                          const Divider(height: 1),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16.0,
+                              vertical: 4.0,
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text(
+                                  I18n.of(context).bookmarkDeepSearchStats(
+                                    _matchedIllustCount.toString(),
+                                    _fetchedIllustCount.toString(),
+                                  ),
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                                Row(
+                                  children: [
+                                    if (_isDeepSearchLoading)
+                                      const Padding(
+                                        padding: EdgeInsets.only(right: 8.0),
+                                        child: SizedBox(
+                                          width: 16,
+                                          height: 16,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        ),
+                                      ),
+                                    Switch(
+                                      value: _isDeepSearching,
+                                      onChanged: (val) async {
+                                        if (val) {
+                                          _startDeepSearch();
+                                        } else {
+                                          await _stopDeepSearch();
+                                        }
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                : const SizedBox(key: ValueKey('bookmark-search-empty')),
           ),
         ],
       ),

--- a/lib/page/user/bookmark/bookmark_search.dart
+++ b/lib/page/user/bookmark/bookmark_search.dart
@@ -1,0 +1,273 @@
+import 'dart:async' show Timer;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:pixez/i18n.dart' show I18n;
+import 'package:pixez/models/tags.dart' as suggestion_models;
+import 'package:pixez/page/search/suggest/suggestion_store.dart'
+    show SuggestionStore;
+
+class BookMarkSearchController extends ChangeNotifier {}
+
+class BookMarkSearchView extends StatefulWidget {
+  BookMarkSearchView({
+    this.suggestionDebounceTime = 250,
+    this.onChange,
+    this.controller,
+    required this.tags,
+  });
+  final List<String> tags;
+  final int suggestionDebounceTime;
+  final BookMarkSearchController? controller;
+  final void Function(List<String>)? onChange;
+
+  @override
+  State<StatefulWidget> createState() => _BookMarkSearchViewState();
+}
+
+class _BookMarkSearchViewState extends State<BookMarkSearchView> {
+  Timer? _suggestionDebounceTimer;
+  late final TextEditingController _textEditingController;
+
+  int get suggestionDebounceTime => widget.suggestionDebounceTime;
+  // The input text is derived from the controller so clearing the field and
+  // hiding suggestions stay in sync.
+  String get _searchInputValue => _textEditingController.text.trim();
+
+  // search suggestion state SuggestionStore::autoWords is observable
+  // SuggestionStore::fetch will perform a auto complete suggestion fetch and update the observable
+  final SuggestionStore _suggestionStore = SuggestionStore();
+
+  @override
+  void initState() {
+    super.initState();
+    _textEditingController = TextEditingController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: _textEditingController,
+          decoration: InputDecoration(
+            // input placeholder
+            hintText: widget.tags.isEmpty
+                ? I18n.of(context).bookmarkSearchTagInputHint
+                : null,
+            // selected tags are implemented as TextField's prefixIcon
+            prefixIcon: widget.tags.isNotEmpty
+                ? SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.only(left: 12.0),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        for (String tag in widget.tags)
+                          _buildSearchTagIconPart(
+                            context,
+                            tag,
+                            onTap: () {
+                              widget.onChange?.call(
+                                widget.tags
+                                    .where((_tag) => _tag != tag)
+                                    .toList(),
+                              );
+                            },
+                          ),
+                      ],
+                    ),
+                  )
+                : const Padding(
+                    padding: EdgeInsets.only(left: 12.0),
+                    child: Icon(Icons.search),
+                  ),
+            prefixIconConstraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.7,
+            ),
+            border: InputBorder.none,
+            contentPadding: const EdgeInsets.symmetric(
+              vertical: 12.0,
+              horizontal: 12.0,
+            ),
+          ),
+          onChanged: (value) {
+            _scheduleSuggestionFetch(value);
+            setState(() {});
+          },
+          onSubmitted: (value) {
+            _submitTag(value);
+          },
+        ),
+        // Auto-complete tags display
+        Observer(
+          builder: (context) {
+            // Suggestions are driven by SuggestionStore.autoWords updates.
+            final suggestionTags =
+                _suggestionStore.autoWords?.tags ??
+                const <suggestion_models.Tags>[];
+            if (_searchInputValue.isEmpty || suggestionTags.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            return Container(
+              constraints: const BoxConstraints(maxHeight: 168),
+              color: Colors.transparent,
+              child: ListView.separated(
+                shrinkWrap: true,
+                padding: const EdgeInsets.symmetric(vertical: 4.0),
+                itemCount: suggestionTags.length,
+                separatorBuilder: (context, index) => Divider(
+                  height: 1,
+                  indent: 12,
+                  endIndent: 12,
+                  color: Theme.of(context).dividerColor.withValues(alpha: 0.35),
+                ),
+                itemBuilder: (BuildContext context, int index) =>
+                    _buildSuggestionItem(
+                      context,
+                      suggestionTags[index],
+                      onTap: () {
+                        _submitTag(suggestionTags[index].name);
+                      },
+                    ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  // should invoke whenever TextField's value changes
+  // if query is not empty, it will trigger/refresh a debounced suggestion fetch
+  // else, any currently debouncing fetch is canceled
+  void _scheduleSuggestionFetch(String query) {
+    _suggestionDebounceTimer?.cancel();
+    query = query.trim();
+    _suggestionStore.clear();
+    if (query.isEmpty) {
+      return;
+    }
+    _suggestionDebounceTimer = Timer(
+      Duration(milliseconds: suggestionDebounceTime),
+      () {
+        // Ignore stale debounce callbacks after the user has edited or cleared
+        // the field again.
+        if (!mounted || _searchInputValue != query) {
+          return;
+        }
+        _suggestionStore.fetch(query);
+      },
+    );
+  }
+
+  void _submitTag(String value) {
+    final tag = value.trim();
+    _suggestionDebounceTimer?.cancel();
+    _suggestionStore.clear();
+    _textEditingController.clear();
+    setState(() {});
+    // Empty and duplicate tags are ignored silently to keep the interaction
+    // lightweight.
+    if (tag.isEmpty) {
+      return;
+    }
+    if (widget.tags.contains(tag)) {
+      return;
+    }
+    widget.onChange?.call([...widget.tags, tag].toSet().toList());
+  }
+
+  // Tags display in the textfield, which is implemented as its Icon
+  // more on this in the main builder
+  Widget _buildSearchTagIconPart(
+    BuildContext context,
+    String tag, {
+    VoidCallback? onTap,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 6.0),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primaryContainer,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(tag),
+            const SizedBox(width: 6),
+            GestureDetector(
+              onTap: onTap,
+              child: const Icon(Icons.close, size: 14),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // Suggestion Item in the suggestion list
+  Widget _buildSuggestionItem(
+    BuildContext context,
+    suggestion_models.Tags tag, {
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+        child: Row(
+          children: [
+            Icon(
+              Icons.sell_outlined,
+              size: 15,
+              color: Theme.of(context).textTheme.bodySmall?.color,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    tag.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium?.copyWith(height: 1.1),
+                  ),
+                  if ((tag.translated_name ?? '').isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2.0),
+                      child: Text(
+                        tag.translated_name!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          height: 1.0,
+                          color: Theme.of(
+                            context,
+                          ).textTheme.bodySmall?.color?.withValues(alpha: 0.72),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _suggestionDebounceTimer?.cancel();
+    _textEditingController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -86,6 +86,8 @@ abstract class _UserSetting with Store {
       "illust_detail_save_skip_long_press";
   static const String DRAG_START_X_KEY = "drag_start_x";
   static const String AUTO_TAG_WHEN_STAR_KEY = "auto_tag_when_star";
+  static const String BOOKMARK_AUTO_REQUEST_INTERVAL_KEY =
+      "bookmark_auto_request_interval";
 
   @observable
   double dragStartX = 0;
@@ -193,6 +195,7 @@ abstract class _UserSetting with Store {
   bool feedAIBadge = false;
   @observable
   bool autoTagWhenStar = false;
+  int bookmarkAutoRequestInterval = 700;
   static const String intialFormat = "{illust_id}_p{part}";
 
   @action
@@ -462,6 +465,9 @@ abstract class _UserSetting with Store {
     autoTagWhenStar = prefs.getBool(AUTO_TAG_WHEN_STAR_KEY) ?? false;
     illustDetailSaveSkipLongPress =
         prefs.getBool(ILLUST_DETAIL_SAVE_SKIP_LONG_PRESS_KEY) ?? false;
+    bookmarkAutoRequestInterval = _normalizeBookmarkAutoRequestInterval(
+      prefs.getInt(BOOKMARK_AUTO_REQUEST_INTERVAL_KEY) ?? 700,
+    );
     if (Platform.isAndroid) {
       try {
         await SecurePlugin.configSecureWindow(nsfwMask);
@@ -641,6 +647,17 @@ abstract class _UserSetting with Store {
   Future<void> setCopyInfoText(String text) async {
     copyInfoText = text;
     await prefs.setString(COPY_INFO_TEXT_KEY, text);
+  }
+
+  int _normalizeBookmarkAutoRequestInterval(int value) {
+    return min(max(value, 100), 10000);
+  }
+
+  @action
+  Future<void> setBookmarkAutoRequestInterval(int value) async {
+    final normalized = _normalizeBookmarkAutoRequestInterval(value);
+    bookmarkAutoRequestInterval = normalized;
+    await prefs.setInt(BOOKMARK_AUTO_REQUEST_INTERVAL_KEY, normalized);
   }
 
   @action

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1003,10 +1003,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1355,10 +1355,9 @@ packages:
   rhttp:
     dependency: "direct main"
     description:
-      name: rhttp
-      sha256: b111638045b730f825a85cb045017b5bd3dfb47b38e98eb293b0519ee6050f2e
-      url: "https://pub.dev"
-    source: hosted
+      path: "third_party/rhttp"
+      relative: true
+    source: path
     version: "0.15.1"
   riverpod:
     dependency: transitive
@@ -1721,26 +1720,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
# 概要

增加了收藏筛选能力，建在了收藏页同页。大致效果：

<img width="300" height="1323" alt="QQ_1773946647548" src="https://github.com/user-attachments/assets/09d6d137-c94f-4519-ae6f-54376525194c" />

# 主要功能

### 多关键字组合筛选
关键字是同时对作品的所有`tag`的`name`, `translated_name`和作品`title`进行字符串匹配，不同tag间是and关系

### 关键词自动补全
输入的时候请求补全接口，基本复用SuggestionStore。

<img width="300" height="1323" alt="QQ_1773947666622" src="https://github.com/user-attachments/assets/69a39b85-a997-4145-87cc-7f0d1c1d3841" />

### 持续请求
提供持续请求switch，打开后会以一定时间间隔自动请求`next_url`来尽可能地多拿收藏记录。

### 持续请求间隔可配置
加在了偏好设置里，默认值700ms，被认为是较保守的安全值，太小的间隔容易触发P站风控。这个值可能待商榷但是本人测试没出过风控：

<img width="300" height="1323" alt="QQ_1773946866154" src="https://github.com/user-attachments/assets/07900bd4-b9c9-41ac-8e83-2a8d994402e2" />

<img width="300" height="1323" alt="QQ_1773946874508" src="https://github.com/user-attachments/assets/ab851f31-c367-45bf-a9f4-7a1eb69e0cd5" />

### 做了适当国际化

# 核心涉及文件

- lib/page/user/bookmark/bookmark_page.dart
- lib/page/user/bookmark/bookmark_search.dart、
- lib/lighting/lighting_page.dart
- lib/page/search/suggest/suggestion_store.dart
- 
# 设计和实现细节

- 搜索Card可以点击新增的放大镜按钮展开，其中包含一个持续搜索switch。如果关闭，lightingPage的刷新和加载功能打开，否则关停，避免用户手动加载时冲突，以及用户下拉刷新重置请求进程导致浪费。
- 给lightingPage加了几个新prop，包括一个controller用于把store暴露给外层，主要用来展示筛选/命中条数。
- 因为收藏接口本身是渐进请求的，所以数据一致性很难保证up-to-date，没有什么比较优雅的方式，所以目前采用轻量一点的设计：如果用户刷新的话就重置请求进度。一个alternative是缓存请求结果，但是如果用户的意图更注重实时性，那么如果用户点掉了一个收藏，我们还缓存着，就不太合适。但是就是容易用户手滑刷新导致全清空。总之就是取舍吧。
- 用户输入trigger请求suggestion这块做了个防抖。用户敲定他临时输入的方式1. 敲回车 2. 点了某个联想。临时输入不纳入实际状态。