### PR TITLE
恢复 pictureSource 替换

### DIFF
--- a/lib/component/pixiv_image.dart
+++ b/lib/component/pixiv_image.dart
@@ -76,17 +76,16 @@ class PixivImage extends StatefulWidget {
     final dio = Dio();
     final client = await r.RhttpCompatibleClient.createSync(
       settings:
-          (userSetting.disableBypassSni ||
-              userSetting.pictureSource != ImageHost)
+          (userSetting.disableBypassSni)
           ? null
           : r.ClientSettings(
               tlsSettings: r.TlsSettings(verifyCertificates: false, sni: false),
               dnsSettings: r.DnsSettings.dynamic(
                 resolver: (host) async {
-                  if (host == 'i.pximg.net') {
+                  if (host == ImageHost) {
                     return [Hoster.iPximgNet()];
                   }
-                  if (host == 's.pximg.net') {
+                  if (host == ImageSHost) {
                     return [Hoster.sPximgNet()];
                   }
                   return await InternetAddress.lookup(

--- a/lib/component/pixiv_image.dart
+++ b/lib/component/pixiv_image.dart
@@ -24,6 +24,7 @@ import 'package:flutter_cache_manager_dio/flutter_cache_manager_dio.dart';
 
 import 'package:pixez/er/hoster.dart';
 import 'package:pixez/er/illust_cacher.dart';
+import 'package:pixez/exts.dart';
 import 'package:pixez/main.dart';
 import 'package:rhttp/rhttp.dart' as r;
 
@@ -95,6 +96,14 @@ class PixivImage extends StatefulWidget {
               ),
             ),
     );
+    dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) {
+        if (options.uri.host == ImageHost || options.uri.host == ImageSHost) {
+          options.path = options.uri.toTureUri().toString();
+        }
+        handler.next(options);
+      },
+    ));
     dio.httpClientAdapter = ConversionLayerAdapter(client);
     DioCacheManager.initialize(dio);
   }

--- a/lib/component/pixiv_image.dart
+++ b/lib/component/pixiv_image.dart
@@ -76,7 +76,8 @@ class PixivImage extends StatefulWidget {
     final dio = Dio();
     final client = await r.RhttpCompatibleClient.createSync(
       settings:
-          (userSetting.disableBypassSni)
+          (userSetting.disableBypassSni ||
+              userSetting.pictureSource != ImageHost)
           ? null
           : r.ClientSettings(
               tlsSettings: r.TlsSettings(verifyCertificates: false, sni: false),

--- a/lib/exts.dart
+++ b/lib/exts.dart
@@ -35,11 +35,6 @@ extension HostExts on Uri {
           return this.replace(host: userSetting.pictureSource);
         } catch (e) {}
       }
-      if (this.host == ImageHost) {
-        return this.replace(host: splashStore.host);
-      } else if (this.host == ImageSHost) {
-        return this.replace(host: splashStore.host);
-      }
     }
     return this;
   }

--- a/lib/fluent/component/pixiv_image.dart
+++ b/lib/fluent/component/pixiv_image.dart
@@ -61,7 +61,8 @@ class PixivImage extends StatefulWidget {
   static Future<void> generatePixivCache() async {
     final dio = Dio();
     final client = await r.RhttpCompatibleClient.createSync(
-        settings: (userSetting.disableBypassSni)
+        settings: (userSetting.disableBypassSni ||
+            userSetting.pictureSource != ImageHost)
             ? null
             : r.ClientSettings(
                 tlsSettings: r.TlsSettings(

--- a/lib/fluent/component/pixiv_image.dart
+++ b/lib/fluent/component/pixiv_image.dart
@@ -22,6 +22,7 @@ import 'package:dio_compatibility_layer/dio_compatibility_layer.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter_cache_manager_dio/flutter_cache_manager_dio.dart';
 import 'package:pixez/er/hoster.dart';
+import 'package:pixez/exts.dart';
 import 'package:pixez/main.dart';
 import 'package:rhttp/rhttp.dart' as r;
 
@@ -78,6 +79,14 @@ class PixivImage extends StatefulWidget {
                   },
                 )));
     dio.interceptors.add(LogInterceptor(responseBody: false));
+    dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) {
+        if (options.uri.host == ImageHost || options.uri.host == ImageSHost) {
+          options.path = options.uri.toTureUri().toString();
+        }
+        handler.next(options);
+      },
+    ));
     dio.httpClientAdapter = ConversionLayerAdapter(client);
     DioCacheManager.initialize(dio);
   }

--- a/lib/fluent/component/pixiv_image.dart
+++ b/lib/fluent/component/pixiv_image.dart
@@ -68,10 +68,10 @@ class PixivImage extends StatefulWidget {
                     verifyCertificates: false, sni: false),
                 dnsSettings: r.DnsSettings.dynamic(
                   resolver: (host) async {
-                    if (host == 'i.pximg.net') {
+                    if (host == ImageHost) {
                       return [Hoster.iPximgNet()];
                     }
-                    if (host == 's.pximg.net') {
+                    if (host == ImageSHost) {
                       return [Hoster.sPximgNet()];
                     }
                     return await InternetAddress.lookup(host)

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -397,7 +397,6 @@ abstract class _UserSetting with Store {
     languageNum = prefs.getInt(LANGUAGE_NUM_KEY) ?? 0;
     disableBypassSni = prefs.getBool('disable_bypass_sni') ?? false;
     ApiClient.Accept_Language = languageList[languageNum];
-    await PixivImage.generatePixivCache();
     await oAuthClient.createDioClient();
     await apiClient.createDioClient();
     apiClient.httpClient.options.headers[HttpHeaders.acceptLanguageHeader] =
@@ -417,6 +416,7 @@ abstract class _UserSetting with Store {
     pictureSource = disableBypassSni
         ? ImageHost
         : (prefs.getString(PICTURE_SOURCE_KEY) ?? ImageHost);
+    await PixivImage.generatePixivCache();
     await Hoster.initMap();
     themeInitState = 1;
     fetcher.start(pictureSource!);


### PR DESCRIPTION
恢复自 90dcc5c (迁移到 rhttp) 删除的 pictureSource 替换。

exts.toTureUri 是这样的:

https://github.com/Notsfsssf/pixez-flutter/blob/2fd38e02a536ad90e959e0777f533c2a561900ef/lib/exts.dart#L22-L46

90dcc5c 移除了所有对 toTureUri 的引用。

Close #946.