### PR TITLE
switch to h3

### DIFF
--- a/lib/er/hoster.dart
+++ b/lib/er/hoster.dart
@@ -11,8 +11,8 @@ import 'package:rhttp/rhttp.dart' as r;
 class Hoster {
   static Map<String, dynamic> _map = Map();
   static Map<String, dynamic> _constMap = {
-    "app-api.pixiv.net": "210.140.139.155",
-    "oauth.secure.pixiv.net": "210.140.139.155",
+    "app-api.pixiv.net": "104.18.42.239",
+    "oauth.secure.pixiv.net": "104.18.42.239",
     "i.pximg.net": "210.140.139.133",
     "s.pximg.net": "210.140.139.133",
     "doh": "doh.dns.sb",

--- a/lib/network/account_client.dart
+++ b/lib/network/account_client.dart
@@ -120,8 +120,7 @@ class AccountClient {
         settings: userSetting.disableBypassSni
             ? null
             : r.ClientSettings(
-                tlsSettings:
-                    r.TlsSettings(verifyCertificates: false, sni: false),
+                httpVersionPref: r.HttpVersionPref.http3,
                 dnsSettings: r.DnsSettings.dynamic(
                   resolver: (host) async {
                     final ip = Hoster.api();

--- a/lib/network/api_client.dart
+++ b/lib/network/api_client.dart
@@ -73,8 +73,7 @@ class ApiClient {
         settings: userSetting.disableBypassSni
             ? null
             : r.ClientSettings(
-                tlsSettings:
-                    r.TlsSettings(verifyCertificates: false, sni: false),
+                httpVersionPref: r.HttpVersionPref.http3,
                 dnsSettings: r.DnsSettings.dynamic(
                   resolver: (host) async {
                     final ip = Hoster.api();
@@ -101,8 +100,7 @@ class ApiClient {
         settings: userSetting.disableBypassSni
             ? null
             : r.ClientSettings(
-                tlsSettings:
-                    r.TlsSettings(verifyCertificates: false, sni: false),
+                httpVersionPref: r.HttpVersionPref.http3,
                 dnsSettings: r.DnsSettings.dynamic(
                   resolver: (host) async {
                     if (host == 'i.pximg.net') {

--- a/lib/network/oauth_client.dart
+++ b/lib/network/oauth_client.dart
@@ -58,8 +58,7 @@ class OAuthClient {
         settings: userSetting.disableBypassSni
             ? null
             : r.ClientSettings(
-                tlsSettings: r.TlsSettings(
-                    verifyCertificates: false, sni: false),
+                httpVersionPref: r.HttpVersionPref.http3,
                 dnsSettings: r.DnsSettings.dynamic(
                   resolver: (host) async {
                     final ip = Hoster.oauth();


### PR DESCRIPTION
目前 GFW 的 [QUIC 封锁列表](https://github.com/gfw-report/usenixsecurity25-quic-sni/blob/main/experiments/sni-blocklist/daily_blocklist/2025-01-19_quic_blocklist.txt)里没有 pixiv.net，可以通过 QUIC 直连。

感觉如果 SNI 匹配、不绕过 Cloudflare 的话就不会遇到 #1164 403？