### PR TITLE
refactor & fix: unify export naming and improve ugoira encoding reliability

### DIFF
--- a/android/app/src/main/kotlin/com/perol/pixez/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/perol/pixez/MainActivity.kt
@@ -117,8 +117,12 @@ class MainActivity : FlutterActivity() {
                 }
 
                 "save" -> {
-                    val data = call.argument<ByteArray>("data")!!
-                    val name = call.argument<String>("name")!!
+                    val data = call.argument<ByteArray>("data")
+                    val name = call.argument<String>("name")
+                    if (data == null || name == null) {
+                        result.error("INVALID_ARGS", "data and name are required", null)
+                        return@setMethodCallHandler
+                    }
                     var clearOld = call.argument<Boolean>("clear_old")
                     saveMode = call.argument<Int>("save_mode") ?: 0
                     if (clearOld == null)
@@ -128,19 +132,23 @@ class MainActivity : FlutterActivity() {
                     savingPools.add(name)
                     lifecycleScope.launch {
                         try {
+                            var saved = false
                             when (saveMode) {
                                 0 -> {
                                     val path = withContext(Dispatchers.IO) {
                                         save(data, name)
-                                    } ?: return@launch
-                                    MediaScannerConnection.scanFile(
-                                        this@MainActivity,
-                                        arrayOf(path),
-                                        arrayOf(
-                                            MimeTypeMap.getSingleton()
-                                                .getMimeTypeFromExtension(File(path).extension)
-                                        )
-                                    ) { _, _ ->
+                                    }
+                                    if (path != null) {
+                                        saved = true
+                                        MediaScannerConnection.scanFile(
+                                            this@MainActivity,
+                                            arrayOf(path),
+                                            arrayOf(
+                                                MimeTypeMap.getSingleton()
+                                                    .getMimeTypeFromExtension(File(path).extension)
+                                            )
+                                        ) { _, _ ->
+                                        }
                                     }
                                 }
 
@@ -182,19 +190,105 @@ class MainActivity : FlutterActivity() {
                                     ) { _, _ ->
                                     }
 
+                                    saved = true
                                 }
 
                                 1 -> {
                                     withContext(Dispatchers.IO) {
-                                        writeFileUri(name, clearOld)?.let {
-                                            wr(data, it)
+                                        val uri = writeFileUri(name, clearOld)
+                                        if (uri != null) {
+                                            wr(data, uri)
+                                            saved = true
                                         }
                                     }
                                 }
                             }
-                            result.success(true)
+                            result.success(saved)
                         } catch (e: Throwable) {
-                            Log.d("x=====", "${e.message}")
+                            Log.d("Save", "${e.message}")
+                            result.success(false)
+                        } finally {
+                            savingPools.remove(name)
+                        }
+                    }
+                }
+
+                "saveFromPath" -> {
+                    val sourcePath = call.argument<String>("source_path")
+                    val name = call.argument<String>("name")
+                    if (sourcePath == null || name == null) {
+                        result.error("INVALID_ARGS", "source_path and name are required", null)
+                        return@setMethodCallHandler
+                    }
+                    var clearOld = call.argument<Boolean>("clear_old")
+                    saveMode = call.argument<Int>("save_mode") ?: 0
+                    if (clearOld == null)
+                        clearOld = false
+                    if (savingPools.contains(name))
+                        return@setMethodCallHandler;
+                    savingPools.add(name)
+                    lifecycleScope.launch {
+                        try {
+                            val sourceFile = File(sourcePath)
+                            var saved = false
+                            when (saveMode) {
+                                0 -> {
+                                    val data = withContext(Dispatchers.IO) {
+                                        sourceFile.readBytes()
+                                    }
+                                    val path = save(data, name)
+                                    if (path != null) {
+                                        saved = true
+                                        MediaScannerConnection.scanFile(
+                                            this@MainActivity,
+                                            arrayOf(path),
+                                            arrayOf(
+                                                MimeTypeMap.getSingleton()
+                                                    .getMimeTypeFromExtension(File(path).extension)
+                                            )
+                                        ) { _, _ ->
+                                        }
+                                    }
+                                }
+
+                                2 -> {
+                                    val target = File("$helplessPath/$name")
+                                    withContext(Dispatchers.IO) {
+                                        val dirPath = target.parent
+                                        val dirFile = File(dirPath)
+                                        if (!dirFile.exists()) {
+                                            dirFile.mkdirs()
+                                        }
+                                        sourceFile.copyTo(target, overwrite = true)
+                                    }
+                                    saved = true
+                                    MediaScannerConnection.scanFile(
+                                        this@MainActivity,
+                                        arrayOf(target.path),
+                                        arrayOf(
+                                            MimeTypeMap.getSingleton()
+                                                .getMimeTypeFromExtension(target.extension)
+                                        )
+                                    ) { _, _ ->
+                                    }
+                                }
+
+                                1 -> {
+                                    withContext(Dispatchers.IO) {
+                                        val uri = writeFileUri(name, clearOld)
+                                        if (uri != null) {
+                                            val data = sourceFile.readBytes()
+                                            wr(data, uri)
+                                            saved = true
+                                        }
+                                    }
+                                }
+                            }
+                            sourceFile.delete()
+                            result.success(saved)
+                        } catch (e: Throwable) {
+                            Log.d("SaveFromPath", "${e.message}")
+                            result.success(false)
                         } finally {
                             savingPools.remove(name)
                         }
@@ -237,20 +331,18 @@ class MainActivity : FlutterActivity() {
             ENCODE_CHANNEL
         ).setMethodCallHandler { call, result ->
             if (call.method == "getBatteryLevel") {
-                val name = call.argument<String>("name")!!
                 val path = call.argument<String>("path")!!
                 val delay = call.argument<Int>("delay")!!
                 val delayArray = call.argument<List<Int>>("delay_array")!!
                 lifecycleScope.launch {
-                    withContext(Dispatchers.IO) {
-                        encodeGif(name, path, delay, delayArray)
+                    val gifPath = withContext(Dispatchers.IO) {
+                        encodeGif(path, delay, delayArray)
                     }
-                    Toast.makeText(
-                        this@MainActivity,
-                        getString(R.string.encode_success),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                    result.success(true)
+                    if (gifPath != null) {
+                        result.success(gifPath)
+                    } else {
+                        result.error("ENCODE_FAILED", "GIF encoding failed", null)
+                    }
                 }
             }
         }
@@ -359,98 +451,49 @@ class MainActivity : FlutterActivity() {
         return list.first().uri.toString()
     }
 
-    private fun encodeGif(name: String, path: String, delay: Int, delayArray: List<Int>) {
+    private fun encodeGif(path: String, delay: Int, delayArray: List<Int>): String? {
         val file = File(path)
-        file.let {
-            val tempFile = File(
-                applicationContext.cacheDir, "${
-                    if (name.contains("/")) {
-                        name.split("/").last()
-                    } else {
-                        name
-                    }
-                }.gif"
-            )
-            try {
-                val fileName = "${name}.gif"
-                if (saveMode == 0) {
-                    if (exist(fileName))
-                        return
-                }
-                /*                if (!tempFile.exists()) {
-                                    tempFile.createNewFile()
-                                }*/
-                Log.d("tempFile path:", tempFile.path)
-                val listFiles = it.listFiles()
-                if (listFiles == null || listFiles.isEmpty()) {
-                    throw RuntimeException("unzip files not found")
-                }
-                val arrayFile = mutableListOf<File>()
-                for (i in listFiles) {
-                    if (i.name.contains("jpg") || i.name.contains("png")) {
-                        arrayFile.add(i)
-                    }
-                }
-                arrayFile.sortWith { o1, o2 -> o1.name.compareTo(o2.name) }
-                val bitmap: Bitmap = BitmapFactory.decodeFile(arrayFile.first().path)
-                val encoder = GifEncoder()
-                encoder.init(
-                    bitmap.width,
-                    bitmap.height,
-                    tempFile.path,
-                    GifEncoder.EncodingType.ENCODING_TYPE_STABLE_HIGH_MEMORY
-                )
-                for (i in arrayFile.indices) {
-                    val trueDelay = if (i < delayArray.size) {
-                        delayArray[i]
-                    } else {
-                        delay
-                    }
-                    if (i != 0) {
-                        encoder.encodeFrame(BitmapFactory.decodeFile(arrayFile[i].path), trueDelay)
-                    } else encoder.encodeFrame(bitmap, trueDelay)
-                }
-                encoder.close()
-                if (saveMode == 0) {
-                    save(tempFile.readBytes(), fileName)?.let {
-                        MediaScannerConnection.scanFile(
-                            this@MainActivity,
-                            arrayOf(it),
-                            arrayOf(
-                                MimeTypeMap.getSingleton()
-                                    .getMimeTypeFromExtension(File(it).extension)
-                            )
-                        ) { _, _ ->
-                        }
-                    }
-                    return
-                }
-                if (saveMode == 2) {
-                    val target = File("$helplessPath/$fileName")
-                    if (!target.exists()) {
-                        target.createNewFile()
-                    }
-                    tempFile.copyTo(target, overwrite = true)
-                    MediaScannerConnection.scanFile(
-                        this@MainActivity,
-                        arrayOf(target.path),
-                        arrayOf(
-                            MimeTypeMap.getSingleton()
-                                .getMimeTypeFromExtension(target.extension)
-                        )
-                    ) { _, _ ->
-                    }
-                    return
-                }
-                val uri = writeFileUri(fileName)
-                contentResolver.openOutputStream(uri!!, "w")?.use { outputStream ->
-                    outputStream.write(tempFile.inputStream().readBytes())
-                }
-            } catch (e: Throwable) {
-                e.printStackTrace()
-                tempFile.delete()
-                it.deleteRecursively()
+        val tempFile = File.createTempFile("encode_", ".gif", applicationContext.cacheDir)
+        try {
+            val listFiles = file.listFiles()
+            if (listFiles == null || listFiles.isEmpty()) {
+                throw RuntimeException("unzip files not found")
             }
+            val arrayFile = mutableListOf<File>()
+            for (i in listFiles) {
+                val ext = i.extension.lowercase()
+                if (ext == "jpg" || ext == "jpeg" || ext == "png") {
+                    arrayFile.add(i)
+                }
+            }
+            arrayFile.sortWith { o1, o2 -> o1.name.compareTo(o2.name) }
+            val bitmap: Bitmap = BitmapFactory.decodeFile(arrayFile.first().path)
+            val encoder = GifEncoder()
+            encoder.init(
+                bitmap.width,
+                bitmap.height,
+                tempFile.path,
+                GifEncoder.EncodingType.ENCODING_TYPE_STABLE_HIGH_MEMORY
+            )
+            for (i in arrayFile.indices) {
+                val trueDelay = if (i < delayArray.size) {
+                    delayArray[i]
+                } else {
+                    delay
+                }
+                if (i != 0) {
+                    val bmp = BitmapFactory.decodeFile(arrayFile[i].path)
+                    encoder.encodeFrame(bmp, trueDelay)
+                    bmp.recycle()
+                } else encoder.encodeFrame(bitmap, trueDelay)
+            }
+            encoder.close()
+            bitmap.recycle()
+            return tempFile.absolutePath
+        } catch (e: Throwable) {
+            e.printStackTrace()
+            tempFile.delete()
+            return null
         }
     }
 

--- a/lib/document_plugin.dart
+++ b/lib/document_plugin.dart
@@ -29,6 +29,16 @@ class DocumentPlugin {
     });
   }
 
+  static Future<bool?> saveFromPath(String sourcePath, String fileName,
+      {bool clearOld = false, int? saveMode}) async {
+    return platform.invokeMethod<bool>('saveFromPath', {
+      "source_path": sourcePath,
+      "name": fileName,
+      "save_mode": saveMode ?? userSetting.saveMode,
+      "clear_old": clearOld
+    });
+  }
+
   static Future<bool?> openSave(Uint8List uint8list, String fileName) {
     return platform.invokeMethod<bool>('openSave', {
       "data": uint8list,

--- a/lib/fluent/page/picture/ugoira_loader.dart
+++ b/lib/fluent/page/picture/ugoira_loader.dart
@@ -86,10 +86,12 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                 onPressed: () async {
                   try {
                     isEncoding = true;
-                    final gifBaseName =
-                        (await buildSaveFileName(
-                                    widget.illusts, 0, ".gif"))
-                            .replaceAll(RegExp(r'\.gif$'), '');
+                    final gifBaseName = await buildSaveFileName(
+                      widget.illusts,
+                      0,
+                      ".gif",
+                      withExtension: false,
+                    );
                     final gifName = applySingleFolder(widget.illusts, gifBaseName);
                     await platform.invokeMethod('getBatteryLevel', {
                       "path": _store.drawPool.first.parent.path,

--- a/lib/fluent/page/picture/ugoira_loader.dart
+++ b/lib/fluent/page/picture/ugoira_loader.dart
@@ -14,20 +14,14 @@
  *
  */
 
-import 'package:bot_toast/bot_toast.dart';
 import 'package:fluent_ui/fluent_ui.dart' hide Image;
-import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/fluent/component/context_menu.dart';
 import 'package:pixez/fluent/component/pixiv_image.dart';
 import 'package:pixez/component/ugoira_painter.dart';
 import 'package:pixez/i18n.dart';
-import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
-import 'package:pixez/store/save_store.dart';
-import 'package:pixez/document_plugin.dart';
-import 'package:pixez/exts.dart';
 
 class UgoiraLoader extends StatefulWidget {
   final int id;
@@ -48,9 +42,6 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
     _store = UgoiraStore(widget.id);
     super.initState();
   }
-
-  bool isEncoding = false;
-  static const platform = const MethodChannel('samples.flutter.dev/battery');
 
   @override
   Widget build(BuildContext context) {
@@ -79,42 +70,15 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
             items: [
               MenuFlyoutItem(
                 text: Text(I18n.of(context).encode_message),
-                onPressed: () {},
+                onPressed: null,
               ),
               MenuFlyoutSeparator(),
               MenuFlyoutItem(
                 text: Text(I18n.of(context).encode),
                 onPressed: () async {
-                  try {
-                    isEncoding = true;
-                    final gifName = await buildSaveFileName(
-                      widget.illusts,
-                      0,
-                      ".gif",
-                    );
-                    BotToast.showText(text: "encoding...");
-                    final gifPath = await platform.invokeMethod('getBatteryLevel', {
-                      "path": _store.drawPool.first.parent.path,
-                      "delay": _store.ugoiraMetadataResponse!.ugoiraMetadata
-                          .frames.first.delay,
-                      "delay_array": _store
-                          .ugoiraMetadataResponse!.ugoiraMetadata.frames
-                          .map((e) => e.delay)
-                          .toList(),
-                    });
-                    if (gifPath != null) {
-                      final targetName = applySingleFolder(widget.illusts, gifName);
-                      await DocumentPlugin.saveFromPath(gifPath, targetName);
-                      BotToast.showText(text: "encode success");
-                    }
-                  } on PlatformException {
-                    isEncoding = false;
-                  }
-                  finally {
-                    isEncoding = false;
-                  }
+                  await _store.encodeGif(widget.illusts);
                 },
-                ),
+              ),
               MenuFlyoutItem(
                 text: Text(I18n.of(context).export),
                 onPressed: () async {

--- a/lib/fluent/page/picture/ugoira_loader.dart
+++ b/lib/fluent/page/picture/ugoira_loader.dart
@@ -26,6 +26,7 @@ import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
 import 'package:pixez/store/save_store.dart';
+import 'package:pixez/document_plugin.dart';
 import 'package:pixez/exts.dart';
 
 class UgoiraLoader extends StatefulWidget {
@@ -86,14 +87,13 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                 onPressed: () async {
                   try {
                     isEncoding = true;
-                    final gifBaseName = await buildSaveFileName(
+                    final gifName = await buildSaveFileName(
                       widget.illusts,
                       0,
                       ".gif",
-                      withExtension: false,
                     );
-                    final gifName = applySingleFolder(widget.illusts, gifBaseName);
-                    await platform.invokeMethod('getBatteryLevel', {
+                    BotToast.showText(text: "encoding...");
+                    final gifPath = await platform.invokeMethod('getBatteryLevel', {
                       "path": _store.drawPool.first.parent.path,
                       "delay": _store.ugoiraMetadataResponse!.ugoiraMetadata
                           .frames.first.delay,
@@ -101,15 +101,20 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                           .ugoiraMetadataResponse!.ugoiraMetadata.frames
                           .map((e) => e.delay)
                           .toList(),
-                      "name": gifName,
                     });
-                    BotToast.showCustomText(
-                        toastBuilder: (_) => Text("encoding..."));
+                    if (gifPath != null) {
+                      final targetName = applySingleFolder(widget.illusts, gifName);
+                      await DocumentPlugin.saveFromPath(gifPath, targetName);
+                      BotToast.showText(text: "encode success");
+                    }
                   } on PlatformException {
                     isEncoding = false;
                   }
+                  finally {
+                    isEncoding = false;
+                  }
                 },
-              ),
+                ),
               MenuFlyoutItem(
                 text: Text(I18n.of(context).export),
                 onPressed: () async {

--- a/lib/fluent/page/picture/ugoira_loader.dart
+++ b/lib/fluent/page/picture/ugoira_loader.dart
@@ -25,6 +25,8 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
+import 'package:pixez/store/save_store.dart';
+import 'package:pixez/exts.dart';
 
 class UgoiraLoader extends StatefulWidget {
   final int id;
@@ -84,6 +86,13 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                 onPressed: () async {
                   try {
                     isEncoding = true;
+                    final gifBaseName =
+                        (await buildSaveFileName(
+                                    widget.illusts, 0, ".gif"))
+                            .replaceAll(RegExp(r'\.gif$'), '');
+                    final gifName = userSetting.singleFolder
+                        ? "${widget.illusts.user.name.toLegal()}_${widget.illusts.user.id}/$gifBaseName"
+                        : gifBaseName;
                     await platform.invokeMethod('getBatteryLevel', {
                       "path": _store.drawPool.first.parent.path,
                       "delay": _store.ugoiraMetadataResponse!.ugoiraMetadata
@@ -92,9 +101,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                           .ugoiraMetadataResponse!.ugoiraMetadata.frames
                           .map((e) => e.delay)
                           .toList(),
-                      "name": userSetting.singleFolder
-                          ? "${widget.illusts.user.name}_${widget.illusts.user.id}/${widget.id}"
-                          : "${widget.id}",
+                      "name": gifName,
                     });
                     BotToast.showCustomText(
                         toastBuilder: (_) => Text("encoding..."));
@@ -106,7 +113,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
               MenuFlyoutItem(
                 text: Text(I18n.of(context).export),
                 onPressed: () async {
-                  await _store.export();
+                  await _store.export(widget.illusts);
                 },
               ),
             ],

--- a/lib/fluent/page/picture/ugoira_loader.dart
+++ b/lib/fluent/page/picture/ugoira_loader.dart
@@ -90,9 +90,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                         (await buildSaveFileName(
                                     widget.illusts, 0, ".gif"))
                             .replaceAll(RegExp(r'\.gif$'), '');
-                    final gifName = userSetting.singleFolder
-                        ? "${widget.illusts.user.name.toLegal()}_${widget.illusts.user.id}/$gifBaseName"
-                        : gifBaseName;
+                    final gifName = applySingleFolder(widget.illusts, gifBaseName);
                     await platform.invokeMethod('getBatteryLevel', {
                       "path": _store.drawPool.first.parent.path,
                       "delay": _store.ugoiraMetadataResponse!.ugoiraMetadata

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -106,10 +106,12 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                   if (result == "OK") {
                     try {
                       isEncoding = true;
-                      final gifBaseName =
-                          (await buildSaveFileName(
-                                      widget.illusts, 0, ".gif"))
-                              .replaceAll(RegExp(r'\.gif$'), '');
+                      final gifBaseName = await buildSaveFileName(
+                        widget.illusts,
+                        0,
+                        ".gif",
+                        withExtension: false,
+                      );
                       final gifName = applySingleFolder(widget.illusts, gifBaseName);
                       platform.invokeMethod('getBatteryLevel', {
                         "path": _store.drawPool.first.parent.path,

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -23,6 +23,7 @@ import 'package:pixez/component/ugoira_painter.dart';
 import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/store/save_store.dart';
+import 'package:pixez/document_plugin.dart';
 import 'package:pixez/exts.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
@@ -106,14 +107,13 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                   if (result == "OK") {
                     try {
                       isEncoding = true;
-                      final gifBaseName = await buildSaveFileName(
+                      final gifName = await buildSaveFileName(
                         widget.illusts,
                         0,
                         ".gif",
-                        withExtension: false,
                       );
-                      final gifName = applySingleFolder(widget.illusts, gifBaseName);
-                      platform.invokeMethod('getBatteryLevel', {
+                      BotToast.showText(text: "encoding...");
+                      final gifPath = await platform.invokeMethod('getBatteryLevel', {
                         "path": _store.drawPool.first.parent.path,
                         "delay": _store
                             .ugoiraMetadataResponse!
@@ -127,12 +127,16 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                             .frames
                             .map((e) => e.delay)
                             .toList(),
-                        "name": gifName,
                       });
-                      BotToast.showCustomText(
-                        toastBuilder: (_) => Text("encoding..."),
-                      );
+                      if (gifPath != null) {
+                        final targetName = applySingleFolder(widget.illusts, gifName);
+                        await DocumentPlugin.saveFromPath(gifPath, targetName);
+                        BotToast.showText(text: "encode success");
+                      }
                     } on PlatformException {
+                      isEncoding = false;
+                    }
+                    finally {
                       isEncoding = false;
                     }
                   } else if (result == "SOURCE") {

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -95,9 +95,9 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                     },
                   );
                   if (result == "OK") {
-                    _store.encodeGif(widget.illusts);
+                    await _store.encodeGif(widget.illusts);
                   } else if (result == "EXPORT") {
-                    _store.export(widget.illusts);
+                    await _store.export(widget.illusts);
                   }
                 },
                 child: UgoiraWidget(

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -14,17 +14,11 @@
  *
  */
 
-import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart' hide Image;
-import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/component/ugoira_painter.dart';
 import 'package:pixez/i18n.dart';
-import 'package:pixez/main.dart';
-import 'package:pixez/store/save_store.dart';
-import 'package:pixez/document_plugin.dart';
-import 'package:pixez/exts.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
 
@@ -48,9 +42,6 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
     super.initState();
   }
 
-  bool isEncoding = false;
-  static const platform = const MethodChannel('samples.flutter.dev/battery');
-
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
@@ -65,7 +56,6 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
             if (_store.status == UgoiraStatus.play) {
               return InkWell(
                 onLongPress: () async {
-                  if (isEncoding) return;
                   final result = await showModalBottomSheet(
                     context: context,
                     shape: RoundedRectangleBorder(
@@ -105,41 +95,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                     },
                   );
                   if (result == "OK") {
-                    try {
-                      isEncoding = true;
-                      final gifName = await buildSaveFileName(
-                        widget.illusts,
-                        0,
-                        ".gif",
-                      );
-                      BotToast.showText(text: "encoding...");
-                      final gifPath = await platform.invokeMethod('getBatteryLevel', {
-                        "path": _store.drawPool.first.parent.path,
-                        "delay": _store
-                            .ugoiraMetadataResponse!
-                            .ugoiraMetadata
-                            .frames
-                            .first
-                            .delay,
-                        "delay_array": _store
-                            .ugoiraMetadataResponse!
-                            .ugoiraMetadata
-                            .frames
-                            .map((e) => e.delay)
-                            .toList(),
-                      });
-                      if (gifPath != null) {
-                        final targetName = applySingleFolder(widget.illusts, gifName);
-                        await DocumentPlugin.saveFromPath(gifPath, targetName);
-                        BotToast.showText(text: "encode success");
-                      }
-                    } on PlatformException {
-                      isEncoding = false;
-                    }
-                    finally {
-                      isEncoding = false;
-                    }
-                  } else if (result == "SOURCE") {
+                    _store.encodeGif(widget.illusts);
                   } else if (result == "EXPORT") {
                     _store.export(widget.illusts);
                   }

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -110,9 +110,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                           (await buildSaveFileName(
                                       widget.illusts, 0, ".gif"))
                               .replaceAll(RegExp(r'\.gif$'), '');
-                      final gifName = userSetting.singleFolder
-                          ? "${widget.illusts.user.name.toLegal()}_${widget.illusts.user.id}/$gifBaseName"
-                          : gifBaseName;
+                      final gifName = applySingleFolder(widget.illusts, gifBaseName);
                       platform.invokeMethod('getBatteryLevel', {
                         "path": _store.drawPool.first.parent.path,
                         "delay": _store

--- a/lib/page/picture/ugoira_loader.dart
+++ b/lib/page/picture/ugoira_loader.dart
@@ -22,6 +22,8 @@ import 'package:pixez/component/pixiv_image.dart';
 import 'package:pixez/component/ugoira_painter.dart';
 import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
+import 'package:pixez/store/save_store.dart';
+import 'package:pixez/exts.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/ugoira_store.dart';
 
@@ -104,6 +106,13 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                   if (result == "OK") {
                     try {
                       isEncoding = true;
+                      final gifBaseName =
+                          (await buildSaveFileName(
+                                      widget.illusts, 0, ".gif"))
+                              .replaceAll(RegExp(r'\.gif$'), '');
+                      final gifName = userSetting.singleFolder
+                          ? "${widget.illusts.user.name.toLegal()}_${widget.illusts.user.id}/$gifBaseName"
+                          : gifBaseName;
                       platform.invokeMethod('getBatteryLevel', {
                         "path": _store.drawPool.first.parent.path,
                         "delay": _store
@@ -118,9 +127,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                             .frames
                             .map((e) => e.delay)
                             .toList(),
-                        "name": userSetting.singleFolder
-                            ? "${widget.illusts.user.name}_${widget.illusts.user.id}/${widget.id}"
-                            : "${widget.id}",
+                        "name": gifName,
                       });
                       BotToast.showCustomText(
                         toastBuilder: (_) => Text("encoding..."),
@@ -130,7 +137,7 @@ class _UgoiraLoaderState extends State<UgoiraLoader> {
                     }
                   } else if (result == "SOURCE") {
                   } else if (result == "EXPORT") {
-                    _store.export();
+                    _store.export(widget.illusts);
                   }
                 },
                 child: UgoiraWidget(

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -52,7 +52,7 @@ abstract class _UgoiraStoreBase with Store {
   List<FileSystemEntity> drawPool = [];
   UgoiraMetadataResponse? ugoiraMetadataResponse;
 
-  export(Illusts illusts) async {
+  Future<void> export(Illusts illusts) async {
     try {
       Directory tempDir = await getTemporaryDirectory();
       String tempPath = tempDir.path;
@@ -78,6 +78,7 @@ abstract class _UgoiraStoreBase with Store {
           zipFolder.createSync(recursive: true);
         }
         File targetFile = File("${zipFolder.path}/$zipFileName");
+        // 当 singleFolder 启用时，targetFile.parent 可能是子目录，需要确保其存在
         targetFile.parent.createSync(recursive: true);
         fullPathFile.copySync(targetFile.path);
         BotToast.showText(text: "export ${targetFile.path} success");

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -17,6 +17,7 @@
 import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:bot_toast/bot_toast.dart';
+import 'package:flutter/services.dart';
 import 'package:dio/dio.dart';
 import 'package:mobx/mobx.dart';
 import 'package:path_provider/path_provider.dart';
@@ -28,7 +29,6 @@ import 'package:pixez/models/ugoira_metadata_response.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:pixez/document_plugin.dart';
 import 'package:pixez/saf_plugin.dart';
-import 'package:pixez/exts.dart';
 import 'package:pixez/models/illust.dart';
 import 'package:pixez/store/save_store.dart';
 
@@ -49,6 +49,11 @@ abstract class _UgoiraStoreBase with Store {
   int count = 0;
   @observable
   int total = 1;
+  @observable
+  bool isEncoding = false;
+
+  static const _platform =
+      const MethodChannel('samples.flutter.dev/battery');
 
   List<FileSystemEntity> drawPool = [];
   UgoiraMetadataResponse? ugoiraMetadataResponse;
@@ -88,6 +93,33 @@ abstract class _UgoiraStoreBase with Store {
     } catch (e) {
       LPrinter.d(e);
       BotToast.showText(text: "export error: ${e.toString()}");
+    }
+  }
+
+  @action
+  Future<void> encodeGif(Illusts illusts) async {
+    if (isEncoding) return;
+    try {
+      isEncoding = true;
+      final gifName = await buildSaveFileName(illusts, 0, ".gif");
+      BotToast.showText(text: "[Encoding] $gifName");
+      final gifPath = await _platform.invokeMethod('getBatteryLevel', {
+        "path": drawPool.first.parent.path,
+        "delay":
+            ugoiraMetadataResponse!.ugoiraMetadata.frames.first.delay,
+        "delay_array": ugoiraMetadataResponse!.ugoiraMetadata.frames
+            .map((e) => e.delay)
+            .toList(),
+      });
+      if (gifPath != null) {
+        final targetName = applySingleFolder(illusts, gifName);
+        await DocumentPlugin.saveFromPath(gifPath, targetName);
+        BotToast.showText(text: "[GifSaved] $gifName");
+      }
+    } on PlatformException {
+      // handled below
+    } finally {
+      isEncoding = false;
     }
   }
 

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -99,12 +99,16 @@ abstract class _UgoiraStoreBase with Store {
   @action
   Future<void> encodeGif(Illusts illusts) async {
     if (isEncoding) return;
+    if (drawPool.isEmpty || ugoiraMetadataResponse == null) {
+      BotToast.showText(text: "not ready");
+      return;
+    }
     try {
       isEncoding = true;
       final gifName = await buildSaveFileName(illusts, 0, ".gif");
       BotToast.showText(text: "[Encoding] $gifName");
       final gifPath = await _platform.invokeMethod('getBatteryLevel', {
-        "path": drawPool.first.parent.path,
+        "path": drawPool.first.parent.path, // guarded by isEmpty check above
         "delay":
             ugoiraMetadataResponse!.ugoiraMetadata.frames.first.delay,
         "delay_array": ugoiraMetadataResponse!.ugoiraMetadata.frames
@@ -116,8 +120,9 @@ abstract class _UgoiraStoreBase with Store {
         await DocumentPlugin.saveFromPath(gifPath, targetName);
         BotToast.showText(text: "[GifSaved] $gifName");
       }
-    } on PlatformException {
-      // handled below
+    } on PlatformException catch (e) {
+      BotToast.showText(
+          text: "encode failed: ${e.message ?? e.toString()}");
     } finally {
       isEncoding = false;
     }

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -27,6 +27,9 @@ import 'package:pixez/main.dart';
 import 'package:pixez/models/ugoira_metadata_response.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:pixez/saf_plugin.dart';
+import 'package:pixez/exts.dart';
+import 'package:pixez/models/illust.dart';
+import 'package:pixez/store/save_store.dart';
 
 part 'ugoira_store.g.dart';
 
@@ -49,7 +52,7 @@ abstract class _UgoiraStoreBase with Store {
   List<FileSystemEntity> drawPool = [];
   UgoiraMetadataResponse? ugoiraMetadataResponse;
 
-  export() async {
+  export(Illusts illusts) async {
     try {
       Directory tempDir = await getTemporaryDirectory();
       String tempPath = tempDir.path;
@@ -57,10 +60,15 @@ abstract class _UgoiraStoreBase with Store {
       File fullPathFile = File(fullPath);
       if (fullPathFile.existsSync()) {
         final data = fullPathFile.readAsBytesSync();
+        String zipFileName = await buildSaveFileName(illusts, 0, ".zip");
+        if (userSetting.singleFolder) {
+          zipFileName =
+              "${illusts.user.name.toLegal()}_${illusts.user.id}/$zipFileName";
+        }
         if (Platform.isAndroid) {
           try {
             String? uriString =
-                await SAFPlugin.createFile("${id}.zip", "application/zip");
+                await SAFPlugin.createFile(zipFileName, "application/zip");
             uriString!;
             await SAFPlugin.writeUri(uriString, data);
             BotToast.showText(text: "export success");
@@ -72,7 +80,8 @@ abstract class _UgoiraStoreBase with Store {
         if (!zipFolder.existsSync()) {
           zipFolder.createSync(recursive: true);
         }
-        File targetFile = File("${zipFolder.path}/${id}.zip");
+        File targetFile = File("${zipFolder.path}/$zipFileName");
+        targetFile.parent.createSync(recursive: true);
         fullPathFile.copySync(targetFile.path);
         BotToast.showText(text: "export ${targetFile.path} success");
       }

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -61,10 +61,7 @@ abstract class _UgoiraStoreBase with Store {
       if (fullPathFile.existsSync()) {
         final data = fullPathFile.readAsBytesSync();
         String zipFileName = await buildSaveFileName(illusts, 0, ".zip");
-        if (userSetting.singleFolder) {
-          zipFileName =
-              "${illusts.user.name.toLegal()}_${illusts.user.id}/$zipFileName";
-        }
+        zipFileName = applySingleFolder(illusts, zipFileName);
         if (Platform.isAndroid) {
           try {
             String? uriString =

--- a/lib/page/picture/ugoira_store.dart
+++ b/lib/page/picture/ugoira_store.dart
@@ -26,6 +26,7 @@ import 'package:pixez/er/lprinter.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/models/ugoira_metadata_response.dart';
 import 'package:pixez/network/api_client.dart';
+import 'package:pixez/document_plugin.dart';
 import 'package:pixez/saf_plugin.dart';
 import 'package:pixez/exts.dart';
 import 'package:pixez/models/illust.dart';
@@ -70,21 +71,23 @@ abstract class _UgoiraStoreBase with Store {
             await SAFPlugin.writeUri(uriString, data);
             BotToast.showText(text: "export success");
             return;
-          } catch (e) {}
+          } catch (e) {
+            BotToast.showText(text: "export cancelled");
+            return;
+          }
         }
-        Directory? directory = await getExternalStorageDirectory();
-        Directory zipFolder = Directory("${directory!.path}/ugoira_zip/");
-        if (!zipFolder.existsSync()) {
-          zipFolder.createSync(recursive: true);
+        final success = await DocumentPlugin.save(data, zipFileName);
+        if (success == true) {
+          BotToast.showText(text: "export success");
+        } else {
+          BotToast.showText(text: "export failed");
         }
-        File targetFile = File("${zipFolder.path}/$zipFileName");
-        // 当 singleFolder 启用时，targetFile.parent 可能是子目录，需要确保其存在
-        targetFile.parent.createSync(recursive: true);
-        fullPathFile.copySync(targetFile.path);
-        BotToast.showText(text: "export ${targetFile.path} success");
+      } else {
+        BotToast.showText(text: "zip file not found, please download first");
       }
     } catch (e) {
       LPrinter.d(e);
+      BotToast.showText(text: "export error: ${e.toString()}");
     }
   }
 

--- a/lib/store/save_store.dart
+++ b/lib/store/save_store.dart
@@ -69,6 +69,35 @@ class JobEntity {
   // JobEntity({required this.max, required this.min, required this.status});
 }
 
+/// 根据用户设置的格式模板或 JS 脚本生成文件名。
+/// [memType] 须包含前导点，如 ".jpg"、".png"、".gif"、".zip"。
+Future<String> buildSaveFileName(
+  Illusts illust,
+  int index,
+  String memType,
+) async {
+  if (userSetting.fileNameEval == 1) {
+    if (userSetting.nameEval != null) {
+      final result = await JSEvalPlugin.eval(
+        illust,
+        userSetting.nameEval!,
+        index,
+        memType,
+      );
+      if (result != null && result.isNotEmpty) return result;
+    } else {
+      await userSetting.setFileNameEval(0);
+    }
+  }
+  final result = userSetting.format!
+      .replaceAll("{illust_id}", illust.id.toString())
+      .replaceAll("{user_id}", illust.user.id.toString())
+      .replaceAll("{part}", index.toString())
+      .replaceAll("{user_name}", illust.user.name.toString())
+      .replaceAll("{title}", illust.title);
+  return "$result$memType".toLegal();
+}
+
 class SaveStore = _SaveStoreBase with _$SaveStore;
 
 abstract class _SaveStoreBase with Store {
@@ -384,48 +413,13 @@ abstract class _SaveStoreBase with Store {
     return result ?? "";
   }
 
-  Future<String?> _handleEvalName(
-    String text,
-    Illusts illust,
-    int index,
-    String memType,
-  ) async {
-    if (userSetting.fileNameEval == 1) {
-      if (userSetting.nameEval == null) {
-        await userSetting.setFileNameEval(0);
-        return null;
-      }
-      return await JSEvalPlugin.eval(
-        illust,
-        userSetting.nameEval!,
-        index,
-        memType,
-      );
-    }
-    return null;
-  }
 
   Future<String> _handleFileName(
     Illusts illust,
     int index,
     String memType,
   ) async {
-    if (userSetting.fileNameEval == 1) {
-      final result = await _handleEvalName(
-        userSetting.nameEval!,
-        illust,
-        index,
-        memType,
-      );
-      if (result != null) return result;
-    }
-    final result = userSetting.format!
-        .replaceAll("{illust_id}", illust.id.toString())
-        .replaceAll("{user_id}", illust.user.id.toString())
-        .replaceAll("{part}", index.toString())
-        .replaceAll("{user_name}", illust.user.name.toString())
-        .replaceAll("{title}", illust.title);
-    return "$result$memType".toLegal();
+    return buildSaveFileName(illust, index, memType);
   }
 
   @action

--- a/lib/store/save_store.dart
+++ b/lib/store/save_store.dart
@@ -112,7 +112,6 @@ String applySingleFolder(Illusts illust, String baseName) {
 }
 
 class SaveStore = _SaveStoreBase with _$SaveStore;
-class SaveStore = _SaveStoreBase with _$SaveStore;
 
 abstract class _SaveStoreBase with Store {
   _SaveStoreBase() {

--- a/lib/store/save_store.dart
+++ b/lib/store/save_store.dart
@@ -98,6 +98,15 @@ Future<String> buildSaveFileName(
   return "$result$memType".toLegal();
 }
 
+/// 如果用户启用了 [singleFolder]，将 [baseName] 包装到作者子目录中。
+String applySingleFolder(Illusts illust, String baseName) {
+  if (userSetting.singleFolder) {
+    return "${illust.user.name.toLegal()}_${illust.user.id}/$baseName";
+  }
+  return baseName;
+}
+
+
 class SaveStore = _SaveStoreBase with _$SaveStore;
 
 abstract class _SaveStoreBase with Store {
@@ -289,11 +298,7 @@ abstract class _SaveStoreBase with Store {
   }) async {
     if (Platform.isAndroid || Platform.isWindows) {
       try {
-        String targetFileName = fileName;
-        if (userSetting.singleFolder) {
-          targetFileName =
-              "${illusts.user.name.toLegal()}_${illusts.user.id}/$fileName";
-        }
+        String targetFileName = applySingleFolder(illusts, fileName);
         final isExist = await DocumentPlugin.exist(targetFileName);
         if (isExist! && !redo) {
           streamController.add(

--- a/lib/store/save_store.dart
+++ b/lib/store/save_store.dart
@@ -71,11 +71,13 @@ class JobEntity {
 
 /// 根据用户设置的格式模板或 JS 脚本生成文件名。
 /// [memType] 须包含前导点，如 ".jpg"、".png"、".gif"、".zip"。
+/// [withExtension] 默认为 true，返回带扩展名的文件名；设为 false 则不带扩展名。
 Future<String> buildSaveFileName(
   Illusts illust,
   int index,
-  String memType,
-) async {
+  String memType, {
+  bool withExtension = true,
+}) async {
   if (userSetting.fileNameEval == 1) {
     if (userSetting.nameEval != null) {
       final result = await JSEvalPlugin.eval(
@@ -95,7 +97,10 @@ Future<String> buildSaveFileName(
       .replaceAll("{part}", index.toString())
       .replaceAll("{user_name}", illust.user.name.toString())
       .replaceAll("{title}", illust.title);
-  return "$result$memType".toLegal();
+  if (withExtension) {
+    return "$result$memType".toLegal();
+  }
+  return result.toLegal();
 }
 
 /// 如果用户启用了 [singleFolder]，将 [baseName] 包装到作者子目录中。
@@ -106,7 +111,7 @@ String applySingleFolder(Illusts illust, String baseName) {
   return baseName;
 }
 
-
+class SaveStore = _SaveStoreBase with _$SaveStore;
 class SaveStore = _SaveStoreBase with _$SaveStore;
 
 abstract class _SaveStoreBase with Store {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -89,7 +89,7 @@ dev_dependencies:
   json_serializable: ^6.8.0
   msix: ^3.16.9
   analyzer: ^8.4.0
-  build_runner: ^2.11.1
+  build_runner: ^2.12.0
   riverpod_generator: ^4.0.0+1
   custom_lint: ^0.8.1
   riverpod_lint: ^3.1.0


### PR DESCRIPTION
## 概述

   此 PR 对 ugoira（动图）导出流程进行重构，统一命名模板并集中编码逻辑，同时改进错误处理。

   ### 重构

   - 提取 `buildSaveFileName()` 为顶层函数，ugoira 导出 GIF/ZIP 复用用户配置的插画保存命名模板（含 JS 脚本支持）
   - 提取 `applySingleFolder()` 方法，消除 `SaveStore` 与 `UgoiraStore` 中 singleFolder 路径构建的重复代码
   - 将 GIF 编码的 `MethodChannel` 调用从 loader widget 收敛到 `UgoiraStore`，loader 仅负责 UI 交互

   ### 可靠性修复

   - 参数安全处理：将 Android 侧 `data`/`name` 的 `!!` 非空断言改为安全判空 + `result.error()`，避免参数缺失时崩溃
   - 编码状态管理：在 `finally` 块中重置 `isEncoding`，防止编码完成后状态卡死
   - 内存管理：GIF 编码过程中及时回收 Bitmap，避免大型动图导致 native OOM
   - 文件筛选：使用扩展名检查替代 `name.contains()`，防止误匹配非图片文件
   - 错误恢复：编码失败时保留源解压目录，支持用户重试而无需重新下载
   - 移除重复的 `SaveStore` 类声明

   ## 测试说明

   这些更改我在个人日常使用中目前未遇到问题，如GIF/ZIP 导出及普通插画保存等，但尚未进行系统性的单元测试。
   如有任何问题或建议，请随时提出。感谢您的时间！
   
Resolves #1213, Resolves #1196