### PR TITLE
迁移 soup_store 到 rhttp

### DIFF
--- a/lib/page/soup/soup_store.dart
+++ b/lib/page/soup/soup_store.dart
@@ -18,12 +18,14 @@ import 'dart:io';
 
 import 'package:bot_toast/bot_toast.dart';
 import 'package:dio/dio.dart';
+import 'package:dio_compatibility_layer/dio_compatibility_layer.dart';
 import 'package:mobx/mobx.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:pixez/main.dart';
 import 'package:pixez/models/amwork.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:html/dom.dart';
+import 'package:rhttp/rhttp.dart' as r;
 
 part 'soup_store.g.dart';
 
@@ -46,6 +48,8 @@ abstract class _SoupStoreBase with Store {
   @action
   fetch(String url) async {
     try {
+      final compatibleClient = await r.RhttpCompatibleClient.create();
+      dio.httpClientAdapter = ConversionLayerAdapter(compatibleClient);
       if (userSetting.languageNum == 0 || userSetting.languageNum >= 5) {
         _fetchEn(url);
       } else {


### PR DESCRIPTION
https://github.com/Notsfsssf/pixez-flutter/issues/1227#issuecomment-4697529227

请求特辑/亮点 www.pixivision.net 子页面时，原 dio 的 TLS 客户端不发送 ALPN 扩展，导致 Cloudflare 返回质询页面。只在中国 IP 地址直连时出现。

<img width="786" height="808" alt="Image" src="https://github.com/user-attachments/assets/25a44fbf-b643-4f41-97b2-cf33c873b007" />

rhttp 会正确发送此扩展。

~~Close~~ #895
~~Close~~ #1044
Close #1227