### PR TITLE
refactor PixezNetworkSettings.forImages for fetcher

### DIFF
--- a/lib/component/pixiv_image.dart
+++ b/lib/component/pixiv_image.dart
@@ -75,7 +75,7 @@ class PixivImage extends StatefulWidget {
 
   static Future<void> generatePixivCache() async {
     final client = await r.RhttpCompatibleClient.createSync(
-      settings: PixezNetworkSettings.forImages(userSetting.networkMode),
+      settings: PixezNetworkSettings.forImages(userSetting.pictureSource, userSetting.networkMode),
     );
     final existing = _cacheDio;
     if (existing != null) {

--- a/lib/er/fetcher.dart
+++ b/lib/er/fetcher.dart
@@ -276,7 +276,7 @@ entryPoint(SendMessage message) async {
   Hoster.dnsQueryFetcher();
   final dio = Dio();
   final client = await r.RhttpCompatibleClient.createSync(
-    settings: PixezNetworkSettings.forImages(message.networkMode),
+    settings: PixezNetworkSettings.forImages(currentPictureSource, currentNetworkMode),
   );
   dio.interceptors.add(
     PixivImageSourceInterceptor(
@@ -295,10 +295,10 @@ entryPoint(SendMessage message) async {
     try {
       IsoContactBean isoContactBean = message;
       if (isoContactBean.state == IsoTaskState.RELOAD) {
-        final mode = isoContactBean.data as NetworkMode;
-        currentNetworkMode = mode;
+        currentNetworkMode = isoContactBean.data.NetworkMode;
+        currentPictureSource = isoContactBean.data.source;
         final newClient = await r.RhttpCompatibleClient.createSync(
-          settings: PixezNetworkSettings.forImages(mode),
+          settings: PixezNetworkSettings.forImages(currentPictureSource, currentNetworkMode),
         );
         dio.httpClientAdapter = ConversionLayerAdapter(newClient);
         return;

--- a/lib/fluent/component/pixiv_image.dart
+++ b/lib/fluent/component/pixiv_image.dart
@@ -63,7 +63,7 @@ class PixivImage extends StatefulWidget {
 
   static Future<void> generatePixivCache() async {
     final client = await r.RhttpCompatibleClient.createSync(
-      settings: PixezNetworkSettings.forImages(userSetting.networkMode),
+      settings: PixezNetworkSettings.forImages(userSetting.pictureSource, userSetting.networkMode),
     );
     final existing = _cacheDio;
     if (existing != null) {

--- a/lib/network/api_client.dart
+++ b/lib/network/api_client.dart
@@ -90,13 +90,9 @@ class ApiClient {
     return httpClient;
   }
 
-  static Future<ConversionLayerAdapter> createCompatibleClient({
-    NetworkMode? networkMode,
-  }) async {
+  static Future<ConversionLayerAdapter> createCompatibleClient() async {
     final compatibleClient = await r.RhttpCompatibleClient.create(
-      settings: PixezNetworkSettings.forImages(
-        networkMode ?? userSetting.networkMode,
-      ),
+      settings: PixezNetworkSettings.compatible(),
     );
     return ConversionLayerAdapter(compatibleClient);
   }

--- a/lib/network/pixez_network_settings.dart
+++ b/lib/network/pixez_network_settings.dart
@@ -29,9 +29,9 @@ class PixezNetworkSettings {
     return compatible();
   }
 
-  static r.ClientSettings? forImages(NetworkMode mode) {
+  static r.ClientSettings? forImages(String? host, NetworkMode mode) {
     if (mode == NetworkMode.standard) return null;
-    if (userSetting.pictureSource != imageHost) return null;
+    if (host != imageHost) return null;
     return compatible();
   }
 


### PR DESCRIPTION
继续 https://t.me/c/1279397557/456220 的问题。在线浏览时自定义图床已经能够正确发送 SNI，但是在 fetcher.dart 下载时仍然走了 compatible 模式，未发送 SNI 导致连接失败。原因是在 fetcher.dart

```dart
if (userSetting.pictureSource != imageHost) return null;
return compatible();
```

此处调用判断时，userSetting.pictureSource 尚未初始化，永远是是默认值 i.pximg.net，因此仍然走了下面的 compatible 。需要给 forImages 添加参数、像 forHost 一样，传入正确的当前 pictureSource。

另外发现 lib/network/api_client.dart createCompatibleClient 对 forImages 的调用是多余的，所有用了 createCompatibleClient 的地方都在之前判断过一次 networkMode，直接返回 compatible 就行。