### PR TITLE
skip pictureSource proxy for s.pximg.net

### DIFF
--- a/lib/er/pixiv_image_source.dart
+++ b/lib/er/pixiv_image_source.dart
@@ -3,7 +3,6 @@ import 'package:pixez/network/network_mode.dart';
 
 class PixivImageSource {
   static const String imageHost = 'i.pximg.net';
-  static const String imageSHost = 's.pximg.net';
 
   static String resolve(
     String url, {
@@ -27,7 +26,7 @@ class PixivImageSource {
     required String? pictureSource,
   }) {
     if (!networkMode.allowsImageSource) return uri;
-    if (uri.host != imageHost && uri.host != imageSHost) return uri;
+    if (uri.host != imageHost) return uri;
 
     final source = pictureSource?.trim();
     if (source == null || source.isEmpty) return uri;


### PR DESCRIPTION
内置的 i.pixiv.re 只代理了 i.pximg.net，没有代理 s.pximg.net，导致评论区贴纸图片无法加载。

<img width="1080" height="900" alt="Screenshot_20260616-152515" src="https://github.com/user-attachments/assets/1f6d67d0-294f-4105-a4e1-4c1fb3c8395e" />

此修改加上目前的自定义图床判断会让 s.pximg.net 的 DNS 和 SNI 未经处理发出，考虑到这个域名没被 DNS 劫持也没被 SNI DPI 封锁这应该不是问题。