### PR TITLE
enable ECH for all pixiv.net subdomains

### DIFF
--- a/lib/network/pixez_network_settings.dart
+++ b/lib/network/pixez_network_settings.dart
@@ -14,7 +14,7 @@ class PixezNetworkSettings {
 
   static r.ClientSettings? forHost(String host, NetworkMode mode) {
     if (mode == NetworkMode.standard) return null;
-    if (host == appApiHost && mode == NetworkMode.ech) {
+    if (mode == NetworkMode.ech) {
       return r.ClientSettings(
         enableEch: true,
         requireEch: true,
@@ -22,6 +22,8 @@ class PixezNetworkSettings {
         dnsSettings: r.DnsSettings.static(
           overrides: {
             appApiHost: ['104.18.10.118', '104.18.11.118'],
+            oauthHost: ['104.18.10.118', '104.18.11.118'],
+            accountHost: ['104.18.10.118', '104.18.11.118'],
           },
         ),
       );

--- a/plugins/rhttp/rust/src/api/client.rs
+++ b/plugins/rhttp/rust/src/api/client.rs
@@ -23,8 +23,7 @@ use tokio::sync::RwLock;
 pub use tokio_util::sync::CancellationToken;
 
 const ALIDNS_RESOLVE_ENDPOINT: &str = "https://dns.alidns.com/resolve";
-const APP_API_PIXIV_NET_HOST: &str = "app-api.pixiv.net";
-const APP_API_PIXIV_NET_ECH_BOOTSTRAP_HOST: &str = "cloudflare-ech.com";
+const ECH_BOOTSTRAP_HOST: &str = "cloudflare-ech.com";
 
 #[derive(Clone)]
 pub struct ClientSettings {
@@ -259,10 +258,6 @@ impl RequestClient {
         let Some(host) = url.host_str() else {
             return false;
         };
-
-        if !host.eq_ignore_ascii_case(APP_API_PIXIV_NET_HOST) {
-            return false;
-        }
 
         if host.parse::<IpAddr>().is_ok() {
             return false;
@@ -726,15 +721,13 @@ impl EchTransport {
     }
 
     async fn lookup_ech_config(&self, host: &str) -> Result<EchLookupResult, RhttpError> {
-        if host.eq_ignore_ascii_case(APP_API_PIXIV_NET_HOST) {
-            let parsed = self
-                .lookup_alidns_https_ech(APP_API_PIXIV_NET_ECH_BOOTSTRAP_HOST)
-                .await?;
-            return Ok(EchLookupResult {
-                ech_config: Some(parsed.ech),
-                ttl: parsed.ttl,
-            });
-        }
+        let parsed = self
+            .lookup_alidns_https_ech(ECH_BOOTSTRAP_HOST)
+            .await?;
+        return Ok(EchLookupResult {
+            ech_config: Some(parsed.ech),
+            ttl: parsed.ttl,
+        });
 
         Ok(EchLookupResult {
             ech_config: None,


### PR DESCRIPTION
在开启 ECH 时 oauth.secure.pixiv.net 仍然使用 compatible 模式直连和触发源站限制。其实所有 pixiv.net 都在 Cloudflare 上，可以全部启用 ECH。

Close #1237
Close #1235
Close #1234