### PR TITLE
clean up saucenao client

### DIFF
--- a/lib/network/pixez_network_settings.dart
+++ b/lib/network/pixez_network_settings.dart
@@ -33,7 +33,6 @@ class PixezNetworkSettings {
 
   static r.ClientSettings? forImages(String? host, NetworkMode mode) {
     if (mode == NetworkMode.standard) return null;
-    if (host != imageHost) return null;
     return compatible();
   }
 

--- a/lib/page/saucenao/sauce_notifier.dart
+++ b/lib/page/saucenao/sauce_notifier.dart
@@ -18,8 +18,6 @@ import 'package:pixez/er/lprinter.dart';
 import 'package:pixez/er/prefer.dart';
 import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
-import 'package:pixez/network/api_client.dart';
-import 'package:pixez/network/network_mode.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -33,11 +31,9 @@ abstract class SauceState with _$SauceState {
 
 @riverpod
 class Sauce extends _$Sauce {
-  static String host = "saucenao.com";
   Dio dio = Dio(
     BaseOptions(
       baseUrl: "https://saucenao.com",
-      headers: {HttpHeaders.hostHeader: host},
     ),
   );
   List<int> results = [];
@@ -143,11 +139,6 @@ class Sauce extends _$Sauce {
     ]);
     try {
       BotToast.showText(text: I18n.ofContext().uploading);
-      if (userSetting.networkMode == NetworkMode.standard) {
-        dio.options.baseUrl = "https://$host";
-      } else {
-        dio.httpClientAdapter = await ApiClient.createCompatibleClient();
-      }
       Response response = await dio.post('/search.php', data: formData);
       BotToast.showText(text: I18n.ofContext().parsing);
       var document = parse(response.data);


### PR DESCRIPTION
#1232 删除了 createCompatibleClient 的 forImages 判断直接返回 compatible 会导致仍在使用 createCompatibleClient 的 saucenao client 不发送 SNI。

而 saucenao 本身没有被封锁，还在 Cloudflare 上，本就不应该带有任何 compatible 配置。

原本 forImages 中的 `if (host != imageHost) return null;` 让 saucenao 能发送 SNI。但是看起来不恰当，如果 host 不是 imageHost 第一步根本不应该走  forImages。