### PR TITLE
修复自定义图床下 ugoira 和用户资料页的图片下载

### DIFF
--- a/lib/network/api_client.dart
+++ b/lib/network/api_client.dart
@@ -92,7 +92,10 @@ class ApiClient {
 
   static Future<ConversionLayerAdapter> createCompatibleClient() async {
     final compatibleClient = await r.RhttpCompatibleClient.create(
-      settings: PixezNetworkSettings.compatible(),
+      settings: PixezNetworkSettings.forImages(
+        userSetting.pictureSource,
+        userSetting.networkMode,
+    ),
     );
     return ConversionLayerAdapter(compatibleClient);
   }


### PR DESCRIPTION
回退我在 #1232 对 createCompatibleClient()  的修改。直接返回了 compatible() 会导致一些页面的在自定义图床请求不发送 SNI。

使用 createCompatibleClient() 的受影响页面有，

* `lib/page/picture/ugoira_store.dart` - 自定义图床下载 ugoira 未发送 SNI 导致 #1255 "i.pixiv.re这个图床加载缩略图挺快的,也没啥毛病,但是加载动图的话,进度条不跑,没法播放"
* `lib/page/user/users_page.dart` 自定义图床下无法保存画师头像
* `lib/fluent/page/user/users_page.dart` 自定义图床下无法保存画师头像
* `lib/page/novel/user/novel_users_page.dart` 自定义图床下无法保存画师头像