### PR TITLE
Windows CI 的临时解决方案

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build Windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     outputs:
       binary-artifact: ${{ steps.binary-artifact.outputs.artifact-url }}
       msix-conclusion: ${{ steps.msix.conclusion }}


### PR DESCRIPTION
ci: 将 Windows 构建环境固定为 windows-2022