### PR TITLE
添加 webpki-root-certs 信任

### DIFF
--- a/plugins/rhttp/rust/Cargo.lock
+++ b/plugins/rhttp/rust/Cargo.lock
@@ -1549,6 +1549,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "webpki-root-certs",
 ]
 
 [[package]]

--- a/plugins/rhttp/rust/Cargo.toml
+++ b/plugins/rhttp/rust/Cargo.toml
@@ -14,6 +14,7 @@ futures-util = "0.3.32"
 rustls = "0.23.37"
 rustls-platform-verifier = "0.6.2"
 serde_json = "1.0.149"
+webpki-root-certs = "1.0"
 tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = "0.7.18"
 

--- a/plugins/rhttp/rust/src/api/client.rs
+++ b/plugins/rhttp/rust/src/api/client.rs
@@ -401,7 +401,7 @@ fn apply_reqwest_tls_settings(
     tls_settings: Option<&TlsSettings>,
 ) -> Result<reqwest::ClientBuilder, RhttpError> {
     let Some(tls_settings) = tls_settings else {
-        return Ok(client);
+        return Ok(client.tls_certs_only(webpki_root_certs()?));
     };
 
     let root_certificates = tls_settings
@@ -416,8 +416,10 @@ fn apply_reqwest_tls_settings(
 
     if !tls_settings.trust_root_certificates {
         client = client.tls_certs_only(root_certificates);
-    } else if !root_certificates.is_empty() {
-        client = client.tls_certs_merge(root_certificates);
+    } else {
+        let mut certs = root_certificates;
+        certs.extend(webpki_root_certs()?);
+        client = client.tls_certs_only(certs);
     }
 
     if tls_settings.verify_certificates {
@@ -658,6 +660,18 @@ fn parse_private_key(private_key: &[u8]) -> Result<PrivateKeyDer<'static>, Rhttp
                 .map_err(|_| "Invalid private key".to_string())
         })
         .map_err(|e| RhttpError::RhttpUnknownError(format!("{e:?}")))
+}
+
+/// The webpki (Mozilla) root certificates bundled with the crate.
+fn webpki_root_certs() -> Result<Vec<Certificate>, RhttpError> {
+    webpki_root_certs::TLS_SERVER_ROOT_CERTS
+        .iter()
+        .map(|der| {
+            Certificate::from_der(der.as_ref()).map_err(|e| {
+                RhttpError::RhttpUnknownError(format!("Error adding webpki root: {e:?}"))
+            })
+        })
+        .collect()
 }
 
 struct StaticResolver {


### PR DESCRIPTION
Close #1231 
Close #1263

参考：

* https://codeberg.org/Tienisto/rhttp/commit/ff0db75bd4 deps: bump reqwest to 0.13
* https://github.com/seanmonstar/reqwest/releases/tag/v0.13.0 rustls roots features removed, `rustls-platform-verifier` is used by default.
* https://codeberg.org/Tienisto/rhttp/commit/63bcc9deb5 feat: add android hook for rustls-platform-verifier (未pick到本仓库)
* https://codeberg.org/Tienisto/rhttp/commit/dae1bcd7f1 feat: rootCertSource

这个 pr chrry-pick 了修复证书信任的 dae1bcd7f1，但是省略了 Platform 路径因为它需要 63bcc9deb5，要改太多了。