### PR TITLE
feat(detail): 支持自定义收藏按钮位置

### DIFF
--- a/lib/component/detail_favorite_button.dart
+++ b/lib/component/detail_favorite_button.dart
@@ -1,0 +1,127 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:pixez/store/user_setting.dart';
+
+const double detailFavoriteFloatingActionButtonSize = 56.0;
+
+class DetailFavoriteButton extends StatelessWidget {
+  const DetailFavoriteButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.heroTag,
+    this.backgroundColor,
+  });
+
+  final Widget icon;
+  final VoidCallback? onPressed;
+  final Object? heroTag;
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      heroTag: heroTag,
+      backgroundColor: backgroundColor,
+      onPressed: onPressed,
+      child: icon,
+    );
+  }
+}
+
+extension DetailFavoriteMaterialButtonSetting on UserSetting {
+  Offset detailFavoriteFractionalOffset({
+    required double x,
+    required double y,
+    required Size areaSize,
+    required Size childSize,
+    double margin = kFloatingActionButtonMargin,
+  }) {
+    final maxX = math.max(margin, areaSize.width - childSize.width - margin);
+    final maxY = math.max(margin, areaSize.height - childSize.height - margin);
+    final safeX = detailFavoriteClampPercent(x);
+    final safeY = detailFavoriteClampPercent(y);
+    return Offset(
+      margin + (maxX - margin) * safeX,
+      margin + (maxY - margin) * safeY,
+    );
+  }
+
+  Offset detailFavoriteFractionalPositionFromOffset({
+    required Offset offset,
+    required Size areaSize,
+    required Size childSize,
+    double margin = kFloatingActionButtonMargin,
+  }) {
+    final maxX = math.max(margin, areaSize.width - childSize.width - margin);
+    final maxY = math.max(margin, areaSize.height - childSize.height - margin);
+    final rangeX = math.max(1.0, maxX - margin);
+    final rangeY = math.max(1.0, maxY - margin);
+    return Offset(
+      detailFavoriteClampPercent((offset.dx - margin) / rangeX),
+      detailFavoriteClampPercent((offset.dy - margin) / rangeY),
+    );
+  }
+
+  double detailFavoriteClampPercent(double value) {
+    return _detailFavoriteClampPercent(value);
+  }
+
+  FloatingActionButtonLocation detailFavoriteFabLocation() {
+    if (!detailFavoriteButtonCustom) {
+      return detailFavoriteButtonLeft
+          ? FloatingActionButtonLocation.startFloat
+          : FloatingActionButtonLocation.endFloat;
+    }
+    return _DetailFavoriteFloatingActionButtonLocation(
+      x: detailFavoriteButtonX,
+      y: detailFavoriteButtonY,
+    );
+  }
+}
+
+double _detailFavoriteClampPercent(double value) {
+  return value.clamp(0.0, 1.0).toDouble();
+}
+
+class _DetailFavoriteFloatingActionButtonLocation
+    extends FloatingActionButtonLocation {
+  const _DetailFavoriteFloatingActionButtonLocation({
+    required this.x,
+    required this.y,
+  });
+
+  final double x;
+  final double y;
+
+  @override
+  Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
+    final fabSize = scaffoldGeometry.floatingActionButtonSize;
+    final minX = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.left;
+    final maxX = math.max(
+      minX,
+      scaffoldGeometry.scaffoldSize.width -
+          fabSize.width -
+          kFloatingActionButtonMargin -
+          scaffoldGeometry.minInsets.right,
+    );
+    final minY = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.top;
+    final bottomLimit = math.min(
+      scaffoldGeometry.scaffoldSize.height,
+      scaffoldGeometry.contentBottom,
+    );
+    final maxY = math.max(
+      minY,
+      bottomLimit -
+          fabSize.height -
+          kFloatingActionButtonMargin -
+          scaffoldGeometry.minInsets.bottom,
+    );
+
+    return Offset(
+      minX + (maxX - minX) * _detailFavoriteClampPercent(x),
+      minY + (maxY - minY) * _detailFavoriteClampPercent(y),
+    );
+  }
+}

--- a/lib/component/star_icon.dart
+++ b/lib/component/star_icon.dart
@@ -14,15 +14,17 @@
  *
  */
 
-import 'package:flutter/material.dart';
+import 'package:fluent_ui/fluent_ui.dart' as fluentui;
+import 'package:flutter/material.dart' as material;
+import 'package:flutter/widgets.dart';
+import 'package:pixez/constants.dart';
 
 class StarIcon extends StatefulWidget {
   final int state;
+  final double boxSize;
 
-  const StarIcon({
-    Key? key,
-    required this.state,
-  }) : super(key: key);
+  const StarIcon({Key? key, required this.state, this.boxSize = 40})
+    : super(key: key);
 
   @override
   _StarIconState createState() => _StarIconState();
@@ -50,9 +52,11 @@ class _StarIconState extends State<StarIcon> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 40,
-      height: 40,
-      color: Colors.transparent,
+      width: widget.boxSize,
+      height: widget.boxSize,
+      color: Constants.isFluent
+          ? fluentui.Colors.transparent
+          : material.Colors.transparent,
       child: _buildData(state),
     );
   }
@@ -61,16 +65,28 @@ class _StarIconState extends State<StarIcon> {
     switch (state) {
       case 0:
         return Icon(
-          Icons.favorite_border,
-          color: Theme.of(context).colorScheme.onSurfaceVariant,
+          Constants.isFluent
+              ? fluentui.FluentIcons.heart
+              : material.Icons.favorite_border,
+          color: Constants.isFluent
+              ? fluentui.FluentTheme.of(context).inactiveColor
+              : material.Theme.of(context).colorScheme.onSurfaceVariant,
         );
       case 1:
-        return Icon(Icons.favorite,
-            color: Theme.of(context).colorScheme.onSurfaceVariant);
+        return Icon(
+          Constants.isFluent
+              ? fluentui.FluentIcons.heart_fill
+              : material.Icons.favorite,
+          color: Constants.isFluent
+              ? fluentui.FluentTheme.of(context).inactiveColor
+              : material.Theme.of(context).colorScheme.onSurfaceVariant,
+        );
       default:
         return Icon(
-          Icons.favorite,
-          color: Colors.red,
+          Constants.isFluent
+              ? fluentui.FluentIcons.heart_fill
+              : material.Icons.favorite,
+          color: Constants.isFluent ? fluentui.Colors.red : material.Colors.red,
         );
     }
   }

--- a/lib/fluent/component/detail_favorite_button.dart
+++ b/lib/fluent/component/detail_favorite_button.dart
@@ -1,0 +1,121 @@
+import 'dart:math' as math;
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:pixez/fluent/component/context_menu.dart';
+import 'package:pixez/store/user_setting.dart';
+
+const double _detailFavoriteButtonMargin = 8.0;
+const double detailFavoriteButtonSize = 48.0;
+
+class DetailFavoriteButton extends StatelessWidget {
+  const DetailFavoriteButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.menuItems = const <MenuFlyoutItemBase>[],
+  });
+
+  final Widget icon;
+  final VoidCallback? onPressed;
+  final List<MenuFlyoutItemBase> menuItems;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = ButtonTheme(
+      data: ButtonThemeData(
+        iconButtonStyle: ButtonStyle(
+          backgroundColor: WidgetStateProperty.all(
+            FluentTheme.of(context).inactiveBackgroundColor,
+          ),
+          shadowColor: WidgetStateProperty.all(
+            FluentTheme.of(context).shadowColor,
+          ),
+          shape: WidgetStateProperty.all(CircleBorder()),
+        ),
+      ),
+      child: IconButton(icon: icon, onPressed: onPressed),
+    );
+
+    return SizedBox(
+      width: detailFavoriteButtonSize,
+      height: detailFavoriteButtonSize,
+      child: Center(
+        child: menuItems.isEmpty
+            ? button
+            : ContextMenu(child: button, items: menuItems),
+      ),
+    );
+  }
+}
+
+extension DetailFavoriteFluentButtonSetting on UserSetting {
+  Alignment detailFavoriteStackAlignment() {
+    return detailFavoriteButtonLeft
+        ? Alignment.bottomLeft
+        : Alignment.bottomRight;
+  }
+
+  EdgeInsets detailFavoriteStackMargin() {
+    return detailFavoriteButtonLeft
+        ? const EdgeInsets.only(
+            left: _detailFavoriteButtonMargin,
+            bottom: _detailFavoriteButtonMargin,
+          )
+        : const EdgeInsets.only(
+            right: _detailFavoriteButtonMargin,
+            bottom: _detailFavoriteButtonMargin,
+          );
+  }
+
+  Offset detailFavoriteStackOffset({
+    required Size areaSize,
+    Size childSize = const Size(
+      detailFavoriteButtonSize,
+      detailFavoriteButtonSize,
+    ),
+  }) {
+    return detailFavoriteFractionalOffset(
+      x: detailFavoriteButtonX,
+      y: detailFavoriteButtonY,
+      areaSize: areaSize,
+      childSize: childSize,
+    );
+  }
+
+  Offset detailFavoriteFractionalOffset({
+    required double x,
+    required double y,
+    required Size areaSize,
+    required Size childSize,
+    double margin = _detailFavoriteButtonMargin,
+  }) {
+    final maxX = math.max(margin, areaSize.width - childSize.width - margin);
+    final maxY = math.max(margin, areaSize.height - childSize.height - margin);
+    final safeX = detailFavoriteClampPercent(x);
+    final safeY = detailFavoriteClampPercent(y);
+    return Offset(
+      margin + (maxX - margin) * safeX,
+      margin + (maxY - margin) * safeY,
+    );
+  }
+
+  Offset detailFavoriteFractionalPositionFromOffset({
+    required Offset offset,
+    required Size areaSize,
+    required Size childSize,
+    double margin = _detailFavoriteButtonMargin,
+  }) {
+    final maxX = math.max(margin, areaSize.width - childSize.width - margin);
+    final maxY = math.max(margin, areaSize.height - childSize.height - margin);
+    final rangeX = math.max(1.0, maxX - margin);
+    final rangeY = math.max(1.0, maxY - margin);
+    return Offset(
+      detailFavoriteClampPercent((offset.dx - margin) / rangeX),
+      detailFavoriteClampPercent((offset.dy - margin) / rangeY),
+    );
+  }
+
+  double detailFavoriteClampPercent(double value) {
+    return value.clamp(0.0, 1.0).toDouble();
+  }
+}

--- a/lib/fluent/page/hello/setting/detail_favorite_button_preview_page.dart
+++ b/lib/fluent/page/hello/setting/detail_favorite_button_preview_page.dart
@@ -1,0 +1,541 @@
+import 'dart:math' as math;
+
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:pixez/component/star_icon.dart';
+import 'package:pixez/fluent/component/detail_favorite_button.dart';
+import 'package:pixez/i18n.dart';
+import 'package:pixez/main.dart';
+
+class DetailFavoriteButtonPreviewPage extends StatefulWidget {
+  const DetailFavoriteButtonPreviewPage({super.key});
+
+  @override
+  State<DetailFavoriteButtonPreviewPage> createState() =>
+      _DetailFavoriteButtonPreviewPageState();
+}
+
+class _DetailFavoriteButtonPreviewPageState
+    extends State<DetailFavoriteButtonPreviewPage> {
+  late final ValueNotifier<Offset> _position;
+
+  @override
+  void initState() {
+    super.initState();
+    _position = ValueNotifier(
+      Offset(
+        userSetting.detailFavoriteButtonCustomX,
+        userSetting.detailFavoriteButtonCustomY,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _commitPosition();
+    _position.dispose();
+    super.dispose();
+  }
+
+  void _setPosition(Offset value) {
+    _position.value = Offset(
+      userSetting.detailFavoriteClampPercent(value.dx),
+      userSetting.detailFavoriteClampPercent(value.dy),
+    );
+  }
+
+  void _commitPosition() {
+    final position = _position.value;
+    userSetting.setDetailFavoriteButtonCustomX(position.dx);
+    userSetting.setDetailFavoriteButtonCustomY(position.dy);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldPage(
+      content: Stack(
+        children: [
+          _DetailPreviewSurface(),
+          _FavoriteButtonPreview(
+            position: _position,
+            onChanged: _setPosition,
+            onChangeEnd: _commitPosition,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FavoriteButtonPreview extends StatefulWidget {
+  const _FavoriteButtonPreview({
+    required this.position,
+    required this.onChanged,
+    required this.onChangeEnd,
+  });
+
+  final ValueListenable<Offset> position;
+  final ValueChanged<Offset> onChanged;
+  final VoidCallback onChangeEnd;
+
+  @override
+  State<_FavoriteButtonPreview> createState() => _FavoriteButtonPreviewState();
+}
+
+class _FavoriteButtonPreviewState extends State<_FavoriteButtonPreview> {
+  Offset? _dragStartPosition;
+  Offset? _dragStartPointer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final areaSize = Size(constraints.maxWidth, constraints.maxHeight);
+          const childSize = Size(
+            detailFavoriteButtonSize,
+            detailFavoriteButtonSize,
+          );
+          return ValueListenableBuilder<Offset>(
+            valueListenable: widget.position,
+            builder: (context, position, child) {
+              final offset = userSetting.detailFavoriteFractionalOffset(
+                x: position.dx,
+                y: position.dy,
+                areaSize: areaSize,
+                childSize: childSize,
+              );
+              return Stack(
+                children: [
+                  Positioned(
+                    left: offset.dx,
+                    top: offset.dy,
+                    child: MouseRegion(
+                      cursor: SystemMouseCursors.move,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onPanStart: (details) {
+                          _dragStartPosition = position;
+                          _dragStartPointer = details.globalPosition;
+                        },
+                        onPanUpdate: (details) {
+                          final startPosition = _dragStartPosition ?? position;
+                          final startPointer =
+                              _dragStartPointer ?? details.globalPosition;
+                          final startOffset = userSetting
+                              .detailFavoriteFractionalOffset(
+                                x: startPosition.dx,
+                                y: startPosition.dy,
+                                areaSize: areaSize,
+                                childSize: childSize,
+                              );
+                          widget.onChanged(
+                            userSetting
+                                .detailFavoriteFractionalPositionFromOffset(
+                                  offset:
+                                      startOffset +
+                                      details.globalPosition -
+                                      startPointer,
+                                  areaSize: areaSize,
+                                  childSize: childSize,
+                                ),
+                          );
+                        },
+                        onPanEnd: (_) => _endDrag(),
+                        onPanCancel: _endDrag,
+                        child: child,
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+            child: DetailFavoriteButton(
+              icon: const StarIcon(state: 0),
+              onPressed: () {},
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _endDrag() {
+    _dragStartPosition = null;
+    _dragStartPointer = null;
+    widget.onChangeEnd();
+  }
+}
+
+class _DetailPreviewSurface extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > constraints.maxHeight;
+        if (isWide && constraints.maxWidth >= 760) {
+          final detailWidth = math.min(320.0, constraints.maxWidth * 0.36);
+          return Row(
+            children: [
+              SizedBox(
+                width: constraints.maxWidth - detailWidth,
+                child: CustomScrollView(
+                  slivers: [
+                    SliverFillRemaining(
+                      child: _PreviewImage(
+                        height: constraints.maxHeight,
+                        compact: true,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Container(
+                  color: FluentTheme.of(context).cardColor,
+                  margin: const EdgeInsets.only(right: 4.0),
+                  child: CustomScrollView(
+                    slivers: _buildDetailSlivers(context, bottomPadding: 24),
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        return CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: _PreviewImage(
+                height: math.max(constraints.maxHeight * 0.58, 360),
+              ),
+            ),
+            ..._buildDetailSlivers(context, bottomPadding: 24),
+          ],
+        );
+      },
+    );
+  }
+
+  List<Widget> _buildDetailSlivers(
+    BuildContext context, {
+    required double bottomPadding,
+  }) {
+    return [
+      SliverToBoxAdapter(child: _PreviewNameAvatar()),
+      SliverToBoxAdapter(child: _PreviewStats()),
+      SliverToBoxAdapter(child: _PreviewTags()),
+      SliverToBoxAdapter(child: _PreviewCaption()),
+      SliverToBoxAdapter(child: _PreviewCommentLink()),
+      SliverToBoxAdapter(child: _PreviewAboutHeader()),
+      _PreviewRecomGrid(),
+      SliverToBoxAdapter(child: SizedBox(height: bottomPadding)),
+    ];
+  }
+}
+
+class _PreviewImage extends StatelessWidget {
+  const _PreviewImage({required this.height, this.compact = false});
+
+  final double height;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Container(
+      height: height,
+      color: theme.inactiveBackgroundColor,
+      alignment: Alignment.center,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = math.min(
+            math.min(
+              constraints.maxWidth * (compact ? 0.82 : 0.78),
+              compact ? 640.0 : 520.0,
+            ),
+            constraints.maxHeight * 0.72,
+          );
+          return SizedBox(
+            width: width,
+            child: AspectRatio(
+              aspectRatio: 0.72,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: theme.cardColor,
+                  borderRadius: BorderRadius.circular(4),
+                  border: Border.all(
+                    color: theme.inactiveColor.withValues(alpha: 0.28),
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  FluentIcons.picture,
+                  size: 64,
+                  color: theme.inactiveColor,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PreviewNameAvatar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SizedBox(
+            height: 70,
+            width: 70,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Container(
+                  height: 70,
+                  width: 70,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: theme.accentColor,
+                  ),
+                ),
+                Container(
+                  height: 58,
+                  width: 58,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: theme.inactiveBackgroundColor,
+                  ),
+                  child: Icon(
+                    FluentIcons.account_browser,
+                    color: theme.inactiveColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                _Line(widthFactor: 0.66, height: 16, accent: true),
+                SizedBox(height: 10),
+                _Line(widthFactor: 0.44),
+                SizedBox(height: 8),
+                _Line(widthFactor: 0.58, height: 10),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewStats extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        children: [
+          _StatsRow(
+            items: [
+              _StatsItem(I18n.of(context).illust_id, "123456789"),
+              _StatsItem(I18n.of(context).pixel, "2400x3600"),
+            ],
+          ),
+          const SizedBox(height: 6),
+          _StatsRow(
+            items: [
+              _StatsItem(I18n.of(context).total_view, "12,345"),
+              _StatsItem(I18n.of(context).total_bookmark, "6,789"),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatsRow extends StatelessWidget {
+  const _StatsRow({required this.items});
+
+  final List<_StatsItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return Wrap(
+      spacing: 20,
+      runSpacing: 6,
+      children: [
+        for (final item in items)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(item.label),
+              const SizedBox(width: 10),
+              Text(item.value, style: TextStyle(color: theme.accentColor)),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+class _StatsItem {
+  const _StatsItem(this.label, this.value);
+
+  final String label;
+  final String value;
+}
+
+class _PreviewTags extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: [
+          _TagPill(width: 72),
+          _TagPill(width: 96),
+          _TagPill(width: 80),
+          _TagPill(width: 116),
+        ],
+      ),
+    );
+  }
+}
+
+class _PreviewCaption extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            _Line(widthFactor: 1),
+            SizedBox(height: 8),
+            _Line(widthFactor: 0.92),
+            SizedBox(height: 8),
+            _Line(widthFactor: 0.64),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PreviewCommentLink extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: HyperlinkButton(
+        onPressed: () {},
+        child: Text(
+          I18n.of(context).view_comment,
+          style: FluentTheme.of(context).typography.body,
+        ),
+      ),
+    );
+  }
+}
+
+class _PreviewAboutHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(I18n.of(context).about_picture),
+    );
+  }
+}
+
+class _PreviewRecomGrid extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SliverGrid(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) => Padding(
+          padding: const EdgeInsets.all(6.0),
+          child: Container(
+            decoration: BoxDecoration(
+              color: FluentTheme.of(context).inactiveBackgroundColor,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Icon(
+              FluentIcons.picture,
+              color: FluentTheme.of(context).inactiveColor,
+            ),
+          ),
+        ),
+        childCount: 6,
+      ),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+      ),
+    );
+  }
+}
+
+class _Line extends StatelessWidget {
+  const _Line({
+    required this.widthFactor,
+    this.height = 12,
+    this.accent = false,
+  });
+
+  final double widthFactor;
+  final double height;
+  final bool accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = FluentTheme.of(context);
+    return FractionallySizedBox(
+      alignment: Alignment.centerLeft,
+      widthFactor: widthFactor,
+      child: Container(
+        height: height,
+        decoration: BoxDecoration(
+          color: accent ? theme.accentColor : theme.inactiveColor,
+          borderRadius: BorderRadius.circular(height / 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _TagPill extends StatelessWidget {
+  const _TagPill({required this.width});
+
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: 28,
+      decoration: BoxDecoration(
+        color: FluentTheme.of(context).inactiveBackgroundColor,
+        borderRadius: BorderRadius.circular(4),
+      ),
+    );
+  }
+}

--- a/lib/fluent/page/hello/setting/setting_quality_page.dart
+++ b/lib/fluent/page/hello/setting/setting_quality_page.dart
@@ -20,6 +20,7 @@ import 'package:bot_toast/bot_toast.dart';
 import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/material.dart' show Icons;
 import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:pixez/component/star_icon.dart';
 import 'package:pixez/fluent/component/pixez_button.dart';
 import 'package:pixez/constants.dart';
 import 'package:pixez/er/leader.dart';
@@ -28,9 +29,11 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/page/about/languages.dart';
 import 'package:pixez/fluent/page/hello/setting/copy_text_page.dart';
+import 'package:pixez/fluent/page/hello/setting/detail_favorite_button_preview_page.dart';
 import 'package:pixez/fluent/page/hello/setting/setting_cross_adapter_page.dart';
 import 'package:pixez/fluent/page/network/network_page.dart';
 import 'package:pixez/fluent/page/platform/platform_page.dart';
+import 'package:pixez/store/detail_favorite_button_position.dart';
 import 'package:pixez/store/welcome_page_type.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -209,7 +212,50 @@ class _SettingQualityPageState extends State<SettingQualityPage>
             ),
           ),
           ListTile(
-            leading: const Icon(Icons.zoom_out_map),
+            leading: const StarIcon(state: 0, boxSize: 18),
+            title: Text(I18n.of(context).detail_favorite_button_position_title),
+            trailing: Row(
+              children: [
+                ComboBox<DetailFavoriteButtonPosition>(
+                  value: userSetting.detailFavoriteButtonPosition,
+                  items: [
+                    ComboBoxItem<DetailFavoriteButtonPosition>(
+                      child: Text(
+                        I18n.of(context).detail_favorite_button_position_right,
+                      ),
+                      value: DetailFavoriteButtonPosition.right,
+                    ),
+                    ComboBoxItem<DetailFavoriteButtonPosition>(
+                      child: Text(
+                        I18n.of(context).detail_favorite_button_position_left,
+                      ),
+                      value: DetailFavoriteButtonPosition.left,
+                    ),
+                    ComboBoxItem<DetailFavoriteButtonPosition>(
+                      child: Text(
+                        I18n.of(context).detail_favorite_button_position_custom,
+                      ),
+                      value: DetailFavoriteButtonPosition.custom,
+                    ),
+                  ],
+                  onChanged: (selected) {
+                    userSetting.setDetailFavoriteButtonPosition(selected!);
+                    if (selected == DetailFavoriteButtonPosition.custom) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) _openDetailFavoriteButtonPreview();
+                      });
+                    }
+                  },
+                ),
+                const Icon(FluentIcons.chevron_right),
+              ],
+            ),
+            onPressed: userSetting.detailFavoriteButtonCustom
+                ? _openDetailFavoriteButtonPreview
+                : null,
+          ),
+          ListTile(
+            leading: const Icon(FluentIcons.full_view),
             title: Text(I18n.of(context).large_preview_zoom_quality),
             trailing: Observer(
               builder: (_) {
@@ -424,7 +470,8 @@ class _SettingQualityPageState extends State<SettingQualityPage>
             ListTile(
               title: Text(I18n.of(context).ignore_current_version_update),
               trailing: ToggleSwitch(
-                checked: Updater.result == Result.yes &&
+                checked:
+                    Updater.result == Result.yes &&
                     Updater.latestVersion != null &&
                     userSetting.ignoreUpdateVersion == Updater.latestVersion,
                 onChanged: (value) async {
@@ -496,6 +543,16 @@ class _SettingQualityPageState extends State<SettingQualityPage>
           ),
         ],
       ),
+    );
+  }
+
+  void _openDetailFavoriteButtonPreview() {
+    Leader.push(
+      context,
+      const DetailFavoriteButtonPreviewPage(),
+      icon: const StarIcon(state: 1, boxSize: 24),
+      title: const Text(""),
+      forceSkipWrap: true,
     );
   }
 

--- a/lib/fluent/page/picture/illust_items_page.dart
+++ b/lib/fluent/page/picture/illust_items_page.dart
@@ -4,21 +4,17 @@ import 'package:fluent_ui/fluent_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/clipboard_plugin.dart';
-import 'package:pixez/fluent/component/ban_page.dart';
-import 'package:pixez/fluent/component/context_menu.dart';
-import 'package:pixez/fluent/component/painter_avatar.dart';
-import 'package:pixez/fluent/component/pixiv_image.dart';
-import 'package:pixez/fluent/component/selectable_html.dart';
 import 'package:pixez/component/null_hero.dart';
 import 'package:pixez/component/star_icon.dart';
 import 'package:pixez/er/leader.dart';
 import 'package:pixez/er/lprinter.dart';
 import 'package:pixez/exts.dart';
-import 'package:pixez/utils.dart';
-import 'package:pixez/i18n.dart';
-import 'package:pixez/main.dart';
-import 'package:pixez/models/ban_illust_id.dart';
-import 'package:pixez/models/illust.dart';
+import 'package:pixez/fluent/component/ban_page.dart';
+import 'package:pixez/fluent/component/context_menu.dart';
+import 'package:pixez/fluent/component/detail_favorite_button.dart';
+import 'package:pixez/fluent/component/painter_avatar.dart';
+import 'package:pixez/fluent/component/pixiv_image.dart';
+import 'package:pixez/fluent/component/selectable_html.dart';
 import 'package:pixez/fluent/page/comment/comment_page.dart';
 import 'package:pixez/fluent/page/picture/picture_list_page.dart';
 import 'package:pixez/fluent/page/picture/row_card.dart';
@@ -26,9 +22,14 @@ import 'package:pixez/fluent/page/picture/tag_for_illust_page.dart';
 import 'package:pixez/fluent/page/picture/ugoira_loader.dart';
 import 'package:pixez/fluent/page/user/users_page.dart';
 import 'package:pixez/fluent/page/zoom/photo_zoom_page.dart';
+import 'package:pixez/i18n.dart';
+import 'package:pixez/main.dart';
+import 'package:pixez/models/ban_illust_id.dart';
+import 'package:pixez/models/illust.dart';
 import 'package:pixez/page/picture/illust_about_store.dart';
 import 'package:pixez/page/picture/illust_store.dart';
 import 'package:pixez/page/user/user_store.dart';
+import 'package:pixez/utils.dart';
 import 'package:share_plus/share_plus.dart';
 
 abstract class IllustItemsPage extends StatefulWidget {
@@ -143,41 +144,44 @@ abstract class IllustItemsPageState extends State<IllustItemsPage>
               }
             }
           }
+          final favoriteButton = DetailFavoriteButton(
+            icon: Observer(builder: (_) => StarIcon(state: illustStore.state)),
+            onPressed: star,
+            menuItems: [
+              MenuFlyoutItem(
+                text: Text(I18n.of(context).favorited_tag),
+                onPressed: () async {
+                  await showBookMarkTag();
+                },
+              ),
+            ],
+          );
+          if (userSetting.detailFavoriteButtonCustom) {
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                final offset = userSetting.detailFavoriteStackOffset(
+                  areaSize: Size(constraints.maxWidth, constraints.maxHeight),
+                );
+                return Stack(
+                  children: [
+                    buildContent(context, illustStore.illusts),
+                    Positioned(
+                      left: offset.dx,
+                      top: offset.dy,
+                      child: favoriteButton,
+                    ),
+                  ],
+                );
+              },
+            );
+          }
           return Stack(
-            alignment: AlignmentDirectional.bottomEnd,
+            alignment: userSetting.detailFavoriteStackAlignment(),
             children: [
               buildContent(context, illustStore.illusts),
               Container(
-                margin: EdgeInsets.only(right: 8.0, bottom: 8.0),
-                child: ContextMenu(
-                  child: ButtonTheme(
-                    child: IconButton(
-                      icon: Observer(
-                        builder: (_) => StarIcon(state: illustStore.state),
-                      ),
-                      onPressed: star,
-                    ),
-                    data: ButtonThemeData(
-                      iconButtonStyle: ButtonStyle(
-                        backgroundColor: WidgetStateProperty.all(
-                          FluentTheme.of(context).inactiveBackgroundColor,
-                        ),
-                        shadowColor: WidgetStateProperty.all(
-                          FluentTheme.of(context).shadowColor,
-                        ),
-                        shape: WidgetStateProperty.all(CircleBorder()),
-                      ),
-                    ),
-                  ),
-                  items: [
-                    MenuFlyoutItem(
-                      text: Text(I18n.of(context).favorited_tag),
-                      onPressed: () async {
-                        await showBookMarkTag();
-                      },
-                    ),
-                  ],
-                ),
+                margin: userSetting.detailFavoriteStackMargin(),
+                child: favoriteButton,
               ),
             ],
           );

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -343,5 +343,9 @@
   "network_mode_ech_message": "Versuche dies, wenn die App geöffnet wird, aber keine Antworten vom Dienst erhält.",
   "network_mode_standard": "Standardverbindung",
   "network_mode_standard_message": "Für die meisten Netzwerke empfohlen.",
-  "ignore_current_version_update": "Aktuelles Update ignorieren"
+  "ignore_current_version_update": "Aktuelles Update ignorieren",
+  "detail_favorite_button_position_title": "Position der Favoriten-Schaltfläche",
+  "detail_favorite_button_position_right": "Rechts",
+  "detail_favorite_button_position_left": "Links",
+  "detail_favorite_button_position_custom": "Benutzerdefiniert"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Favorite button position",
+  "detail_favorite_button_position_right": "Right",
+  "detail_favorite_button_position_left": "Left",
+  "detail_favorite_button_position_custom": "Custom"
 }

--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -343,5 +343,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Favorite button position",
+  "detail_favorite_button_position_right": "Right",
+  "detail_favorite_button_position_left": "Left",
+  "detail_favorite_button_position_custom": "Custom"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -333,5 +333,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Posición del botón de favorito",
+  "detail_favorite_button_position_right": "Derecha",
+  "detail_favorite_button_position_left": "Izquierda",
+  "detail_favorite_button_position_custom": "Personalizada"
 }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Posisyon ng button ng bookmark",
+  "detail_favorite_button_position_right": "Kanan",
+  "detail_favorite_button_position_left": "Kaliwa",
+  "detail_favorite_button_position_custom": "Custom"
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Posisi tombol favorit",
+  "detail_favorite_button_position_right": "Kanan",
+  "detail_favorite_button_position_left": "Kiri",
+  "detail_favorite_button_position_custom": "Kustom"
 }

--- a/lib/l10n/intl_id_ID.arb
+++ b/lib/l10n/intl_id_ID.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Posisi tombol favorit",
+  "detail_favorite_button_position_right": "Kanan",
+  "detail_favorite_button_position_left": "Kiri",
+  "detail_favorite_button_position_custom": "Kustom"
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "お気に入りボタンの位置",
+  "detail_favorite_button_position_right": "右側",
+  "detail_favorite_button_position_left": "左側",
+  "detail_favorite_button_position_custom": "カスタム"
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "즐겨찾기 버튼 위치",
+  "detail_favorite_button_position_right": "오른쪽",
+  "detail_favorite_button_position_left": "왼쪽",
+  "detail_favorite_button_position_custom": "사용자 지정"
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Расположение кнопки избранного",
+  "detail_favorite_button_position_right": "Справа",
+  "detail_favorite_button_position_left": "Слева",
+  "detail_favorite_button_position_custom": "Настроить"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -343,5 +343,9 @@
   "network_mode_ech_message": "Uygulama açıldığı halde hizmet yanıtları başarısız olduğunda bunu dene.",
   "network_mode_standard": "Standart bağlantı",
   "network_mode_standard_message": "Çoğu ağ için önerilir.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Favori düğmesi konumu",
+  "detail_favorite_button_position_right": "Sağ",
+  "detail_favorite_button_position_left": "Sol",
+  "detail_favorite_button_position_custom": "Özel"
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Vị trí nút yêu thích",
+  "detail_favorite_button_position_right": "Bên phải",
+  "detail_favorite_button_position_left": "Bên trái",
+  "detail_favorite_button_position_custom": "Tùy chỉnh"
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "detail_favorite_button_position_title": "Vị trí nút yêu thích",
+  "detail_favorite_button_position_right": "Bên phải",
+  "detail_favorite_button_position_left": "Bên trái",
+  "detail_favorite_button_position_custom": "Tùy chỉnh"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -342,5 +342,9 @@
   "network_mode_ech_message": "登录后接口返回异常时尝试。",
   "network_mode_standard": "标准连接",
   "network_mode_standard_message": "大多数网络环境推荐使用。",
-  "ignore_current_version_update": "忽略当前版本更新"
+  "ignore_current_version_update": "忽略当前版本更新",
+  "detail_favorite_button_position_title": "收藏按钮位置",
+  "detail_favorite_button_position_right": "右侧",
+  "detail_favorite_button_position_left": "左侧",
+  "detail_favorite_button_position_custom": "自定义"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -343,5 +343,9 @@
   "network_mode_ech_message": "登录后接口返回异常时尝试。",
   "network_mode_standard": "标准连接",
   "network_mode_standard_message": "大多数网络环境推荐使用。",
-  "ignore_current_version_update": "忽略当前版本更新"
+  "ignore_current_version_update": "忽略当前版本更新",
+  "detail_favorite_button_position_title": "收藏按钮位置",
+  "detail_favorite_button_position_right": "右侧",
+  "detail_favorite_button_position_left": "左侧",
+  "detail_favorite_button_position_custom": "自定义"
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -343,5 +343,9 @@
   "network_mode_ech_message": "登入後服務回應異常時嘗試。",
   "network_mode_standard": "標準連線",
   "network_mode_standard_message": "建議大多數網路環境使用。",
-  "ignore_current_version_update": "忽略当前版本更新"
+  "ignore_current_version_update": "忽略当前版本更新",
+  "detail_favorite_button_position_title": "收藏按鈕位置",
+  "detail_favorite_button_position_right": "右側",
+  "detail_favorite_button_position_left": "左側",
+  "detail_favorite_button_position_custom": "自訂"
 }

--- a/lib/page/hello/setting/detail_favorite_button_preview_page.dart
+++ b/lib/page/hello/setting/detail_favorite_button_preview_page.dart
@@ -1,0 +1,543 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:pixez/component/detail_favorite_button.dart';
+import 'package:pixez/component/star_icon.dart';
+import 'package:pixez/i18n.dart';
+import 'package:pixez/main.dart';
+
+class DetailFavoriteButtonPreviewPage extends StatefulWidget {
+  const DetailFavoriteButtonPreviewPage({super.key});
+
+  @override
+  State<DetailFavoriteButtonPreviewPage> createState() =>
+      _DetailFavoriteButtonPreviewPageState();
+}
+
+class _DetailFavoriteButtonPreviewPageState
+    extends State<DetailFavoriteButtonPreviewPage> {
+  late final ValueNotifier<Offset> _position;
+
+  @override
+  void initState() {
+    super.initState();
+    _position = ValueNotifier(
+      Offset(
+        userSetting.detailFavoriteButtonCustomX,
+        userSetting.detailFavoriteButtonCustomY,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _commitPosition();
+    _position.dispose();
+    super.dispose();
+  }
+
+  void _setPosition(Offset value) {
+    _position.value = Offset(
+      userSetting.detailFavoriteClampPercent(value.dx),
+      userSetting.detailFavoriteClampPercent(value.dy),
+    );
+  }
+
+  void _commitPosition() {
+    final position = _position.value;
+    userSetting.setDetailFavoriteButtonCustomX(position.dx);
+    userSetting.setDetailFavoriteButtonCustomY(position.dy);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBody: true,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(backgroundColor: Colors.transparent, elevation: 0),
+      body: Stack(
+        children: [
+          _DetailPreviewSurface(),
+          _FavoriteButtonPreview(
+            position: _position,
+            onChanged: _setPosition,
+            onChangeEnd: _commitPosition,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FavoriteButtonPreview extends StatefulWidget {
+  const _FavoriteButtonPreview({
+    required this.position,
+    required this.onChanged,
+    required this.onChangeEnd,
+  });
+
+  final ValueListenable<Offset> position;
+  final ValueChanged<Offset> onChanged;
+  final VoidCallback onChangeEnd;
+
+  @override
+  State<_FavoriteButtonPreview> createState() => _FavoriteButtonPreviewState();
+}
+
+class _FavoriteButtonPreviewState extends State<_FavoriteButtonPreview> {
+  Offset? _dragStartPosition;
+  Offset? _dragStartPointer;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final areaSize = Size(constraints.maxWidth, constraints.maxHeight);
+          const childSize = Size(
+            detailFavoriteFloatingActionButtonSize,
+            detailFavoriteFloatingActionButtonSize,
+          );
+          return ValueListenableBuilder<Offset>(
+            valueListenable: widget.position,
+            builder: (context, position, child) {
+              final offset = userSetting.detailFavoriteFractionalOffset(
+                x: position.dx,
+                y: position.dy,
+                areaSize: areaSize,
+                childSize: childSize,
+              );
+              return Stack(
+                children: [
+                  Positioned(
+                    left: offset.dx,
+                    top: offset.dy,
+                    child: MouseRegion(
+                      cursor: SystemMouseCursors.move,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onPanStart: (details) {
+                          _dragStartPosition = position;
+                          _dragStartPointer = details.globalPosition;
+                        },
+                        onPanUpdate: (details) {
+                          final startPosition = _dragStartPosition ?? position;
+                          final startPointer =
+                              _dragStartPointer ?? details.globalPosition;
+                          final startOffset = userSetting
+                              .detailFavoriteFractionalOffset(
+                                x: startPosition.dx,
+                                y: startPosition.dy,
+                                areaSize: areaSize,
+                                childSize: childSize,
+                              );
+                          widget.onChanged(
+                            userSetting
+                                .detailFavoriteFractionalPositionFromOffset(
+                                  offset:
+                                      startOffset +
+                                      details.globalPosition -
+                                      startPointer,
+                                  areaSize: areaSize,
+                                  childSize: childSize,
+                                ),
+                          );
+                        },
+                        onPanEnd: (_) => _endDrag(),
+                        onPanCancel: _endDrag,
+                        child: child,
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+            child: DetailFavoriteButton(
+              heroTag: null,
+              onPressed: () {},
+              icon: const StarIcon(state: 0),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  void _endDrag() {
+    _dragStartPosition = null;
+    _dragStartPointer = null;
+    widget.onChangeEnd();
+  }
+}
+
+class _DetailPreviewSurface extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > constraints.maxHeight;
+        if (isWide && constraints.maxWidth >= 760) {
+          final detailWidth = math.min(320.0, constraints.maxWidth * 0.36);
+          return Row(
+            children: [
+              SizedBox(
+                width: constraints.maxWidth - detailWidth,
+                child: CustomScrollView(
+                  slivers: [
+                    SliverFillRemaining(
+                      child: _PreviewImage(
+                        height: constraints.maxHeight,
+                        compact: true,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Container(
+                  color: colorScheme.surface,
+                  margin: const EdgeInsets.only(right: 4.0),
+                  child: CustomScrollView(
+                    slivers: _buildDetailSlivers(context, bottomPadding: 24),
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        return CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: _PreviewImage(
+                height: math.max(constraints.maxHeight * 0.58, 360),
+              ),
+            ),
+            ..._buildDetailSlivers(context, bottomPadding: 24),
+          ],
+        );
+      },
+    );
+  }
+
+  List<Widget> _buildDetailSlivers(
+    BuildContext context, {
+    required double bottomPadding,
+  }) {
+    return [
+      SliverToBoxAdapter(child: _PreviewNameAvatar()),
+      SliverToBoxAdapter(child: _PreviewStats()),
+      SliverToBoxAdapter(child: _PreviewTags()),
+      SliverToBoxAdapter(child: _PreviewCaption()),
+      SliverToBoxAdapter(child: _PreviewCommentLink()),
+      SliverToBoxAdapter(child: _PreviewAboutHeader()),
+      _PreviewRecomGrid(),
+      SliverToBoxAdapter(child: SizedBox(height: bottomPadding)),
+    ];
+  }
+}
+
+class _PreviewImage extends StatelessWidget {
+  const _PreviewImage({required this.height, this.compact = false});
+
+  final double height;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      height: height,
+      color: colorScheme.surfaceContainerHighest,
+      alignment: Alignment.center,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = math.min(
+            math.min(
+              constraints.maxWidth * (compact ? 0.82 : 0.78),
+              compact ? 640.0 : 520.0,
+            ),
+            constraints.maxHeight * 0.72,
+          );
+          return SizedBox(
+            width: width,
+            child: AspectRatio(
+              aspectRatio: 0.72,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: colorScheme.surface,
+                  borderRadius: BorderRadius.circular(4),
+                  border: Border.all(color: colorScheme.outlineVariant),
+                ),
+                alignment: Alignment.center,
+                child: Icon(
+                  Icons.image_outlined,
+                  size: 64,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _PreviewNameAvatar extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: SizedBox(
+            height: 70,
+            width: 70,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                Container(
+                  height: 70,
+                  width: 70,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.primary,
+                  ),
+                ),
+                Container(
+                  height: 58,
+                  width: 58,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.surfaceContainerHighest,
+                  ),
+                  child: Icon(
+                    Icons.person_outline,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: const [
+                _Line(widthFactor: 0.66, height: 16, accent: true),
+                SizedBox(height: 10),
+                _Line(widthFactor: 0.44),
+                SizedBox(height: 8),
+                _Line(widthFactor: 0.58, height: 10),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewStats extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        children: [
+          _StatsRow(
+            items: [
+              _StatsItem(I18n.of(context).illust_id, "123456789"),
+              _StatsItem(I18n.of(context).pixel, "2400x3600"),
+            ],
+          ),
+          const SizedBox(height: 6),
+          _StatsRow(
+            items: [
+              _StatsItem(I18n.of(context).total_view, "12,345"),
+              _StatsItem(I18n.of(context).total_bookmark, "6,789"),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatsRow extends StatelessWidget {
+  const _StatsRow({required this.items});
+
+  final List<_StatsItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Wrap(
+      spacing: 20,
+      runSpacing: 6,
+      children: [
+        for (final item in items)
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(item.label),
+              const SizedBox(width: 10),
+              Text(item.value, style: TextStyle(color: colorScheme.primary)),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+class _StatsItem {
+  const _StatsItem(this.label, this.value);
+
+  final String label;
+  final String value;
+}
+
+class _PreviewTags extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 6,
+        runSpacing: 6,
+        children: [
+          _ChipLine(width: 72),
+          _ChipLine(width: 96),
+          _ChipLine(width: 80),
+          _ChipLine(width: 116),
+        ],
+      ),
+    );
+  }
+}
+
+class _PreviewCaption extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            _Line(widthFactor: 1),
+            SizedBox(height: 8),
+            _Line(widthFactor: 0.92),
+            SizedBox(height: 8),
+            _Line(widthFactor: 0.64),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PreviewCommentLink extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: TextButton(
+        onPressed: () {},
+        child: Text(I18n.of(context).view_comment),
+      ),
+    );
+  }
+}
+
+class _PreviewAboutHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Text(I18n.of(context).about_picture),
+    );
+  }
+}
+
+class _PreviewRecomGrid extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return SliverGrid(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) => Padding(
+          padding: const EdgeInsets.all(6.0),
+          child: Container(
+            decoration: BoxDecoration(
+              color: colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Icon(
+              Icons.image_outlined,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        childCount: 6,
+      ),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+      ),
+    );
+  }
+}
+
+class _Line extends StatelessWidget {
+  const _Line({
+    required this.widthFactor,
+    this.height = 12,
+    this.accent = false,
+  });
+
+  final double widthFactor;
+  final double height;
+  final bool accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return FractionallySizedBox(
+      alignment: Alignment.centerLeft,
+      widthFactor: widthFactor,
+      child: Container(
+        height: height,
+        decoration: BoxDecoration(
+          color: accent ? colorScheme.primary : colorScheme.outlineVariant,
+          borderRadius: BorderRadius.circular(height / 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _ChipLine extends StatelessWidget {
+  const _ChipLine({required this.width});
+
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      width: width,
+      height: 28,
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(14),
+      ),
+    );
+  }
+}

--- a/lib/page/hello/setting/setting_quality_page.dart
+++ b/lib/page/hello/setting/setting_quality_page.dart
@@ -21,6 +21,7 @@ import 'package:bot_toast/bot_toast.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/app_widget_plugin.dart';
+import 'package:pixez/component/star_icon.dart';
 import 'package:pixez/constants.dart';
 import 'package:pixez/er/leader.dart';
 import 'package:pixez/er/prefer.dart';
@@ -29,9 +30,11 @@ import 'package:pixez/i18n.dart';
 import 'package:pixez/main.dart';
 import 'package:pixez/page/about/languages.dart';
 import 'package:pixez/page/hello/setting/copy_text_page.dart';
+import 'package:pixez/page/hello/setting/detail_favorite_button_preview_page.dart';
 import 'package:pixez/page/hello/setting/setting_cross_adapter_page.dart';
 import 'package:pixez/page/network/network_page.dart';
 import 'package:pixez/page/platform/platform_page.dart';
+import 'package:pixez/store/detail_favorite_button_position.dart';
 import 'package:pixez/store/welcome_page_type.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -182,6 +185,33 @@ class _SettingQualityPageState extends State<SettingQualityPage>
                       userSetting.setMangaQuality(index);
                     },
                   ),
+                ),
+                ListTile(
+                  leading: const StarIcon(state: 1, boxSize: 24),
+                  title: Text(
+                    I18n.of(context).detail_favorite_button_position_title,
+                  ),
+                  trailing: SettingSelectMenu(
+                    index: userSetting.detailFavoriteButtonPosition.index,
+                    items: [
+                      I18n.of(context).detail_favorite_button_position_right,
+                      I18n.of(context).detail_favorite_button_position_left,
+                      I18n.of(context).detail_favorite_button_position_custom,
+                    ],
+                    onChange: (index) {
+                      final position =
+                          DetailFavoriteButtonPosition.values[index];
+                      userSetting.setDetailFavoriteButtonPosition(position);
+                      if (position == DetailFavoriteButtonPosition.custom) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (mounted) _openDetailFavoriteButtonPreview();
+                        });
+                      }
+                    },
+                  ),
+                  onTap: userSetting.detailFavoriteButtonCustom
+                      ? _openDetailFavoriteButtonPreview
+                      : null,
                 ),
                 ListTile(
                   leading: const Icon(Icons.zoom_out_map),
@@ -367,9 +397,11 @@ class _SettingQualityPageState extends State<SettingQualityPage>
                 ),
                 if (!Constants.isGooglePlay && !Platform.isIOS)
                   SwitchListTile(
-                    value: Updater.result == Result.yes &&
+                    value:
+                        Updater.result == Result.yes &&
                         Updater.latestVersion != null &&
-                        userSetting.ignoreUpdateVersion == Updater.latestVersion,
+                        userSetting.ignoreUpdateVersion ==
+                            Updater.latestVersion,
                     title: Text(I18n.of(context).ignore_current_version_update),
                     onChanged: (value) async {
                       if (value) {
@@ -434,6 +466,14 @@ class _SettingQualityPageState extends State<SettingQualityPage>
             ),
           );
         },
+      ),
+    );
+  }
+
+  void _openDetailFavoriteButtonPreview() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const DetailFavoriteButtonPreviewPage(),
       ),
     );
   }

--- a/lib/page/picture/illust_lighting_page.dart
+++ b/lib/page/picture/illust_lighting_page.dart
@@ -24,6 +24,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/component/ban_page.dart';
 import 'package:pixez/component/common_back_area.dart';
+import 'package:pixez/component/detail_favorite_button.dart';
 import 'package:pixez/component/null_hero.dart';
 import 'package:pixez/component/painter_avatar.dart';
 import 'package:pixez/component/pixez_default_header.dart';
@@ -263,86 +264,94 @@ class _IllustVerticalPageState extends State<IllustVerticalPage>
         onTap: () {
           FocusManager.instance.primaryFocus?.unfocus();
         },
-        child: Scaffold(
-          extendBody: true,
-          extendBodyBehindAppBar: true,
-          floatingActionButton: GestureDetector(
-            onLongPress: () {
-              _showBookMarkTag();
-            },
-            onHorizontalDragEnd: (DragEndDetails detail) {
-              if (widget.onHorizontalDragEnd != null) {
-                widget.onHorizontalDragEnd!(detail);
-              }
-            },
-            child: Observer(
-              builder: (context) {
-                return Visibility(
-                  visible: _illustStore.errorMessage == null,
-                  child: FloatingActionButton(
-                    heroTag: widget.id,
-                    onPressed: () async {
-                      if (userSetting.saveAfterStar &&
-                          (_illustStore.state == 0)) {
-                        saveStore.saveImage(_illustStore.illusts!);
-                      }
-                      // TODO: 添加配置项 开关和过滤器
-                      final List<String>? tags;
-                      if (userSetting.autoTagWhenStar) {
-                        final filters = [RegExp(r"\d+users入り")];
-                        tags = _illustStore.illusts!.tags
-                            .map((tag) => tag.name)
-                            .where(
-                              (tag) =>
-                                  !filters.any((regex) => regex.hasMatch(tag)),
-                            )
-                            .toList();
-                      } else {
-                        tags = null;
-                      }
-                      bool success = await _illustStore.star(
-                        restrict: userSetting.defaultPrivateLike
-                            ? "private"
-                            : "public",
-                        tags: tags,
-                      );
-                      if (success && userSetting.followAfterStar) {
-                        bool followSuccess = await _illustStore.followAfterStar();
-                        if (followSuccess) {
-                          userStore?.isFollow = true;
-                          BotToast.showText(
-                            text:
-                                "${_illustStore.illusts!.user.name} ${I18n.of(context).followed}",
+        child: Observer(
+          builder: (_) {
+            return Scaffold(
+              extendBody: true,
+              extendBodyBehindAppBar: true,
+              floatingActionButtonLocation: userSetting
+                  .detailFavoriteFabLocation(),
+              floatingActionButton: GestureDetector(
+                onLongPress: () {
+                  _showBookMarkTag();
+                },
+                onHorizontalDragEnd: (DragEndDetails detail) {
+                  if (widget.onHorizontalDragEnd != null) {
+                    widget.onHorizontalDragEnd!(detail);
+                  }
+                },
+                child: Observer(
+                  builder: (context) {
+                    return Visibility(
+                      visible: _illustStore.errorMessage == null,
+                      child: DetailFavoriteButton(
+                        heroTag: widget.id,
+                        onPressed: () async {
+                          if (userSetting.saveAfterStar &&
+                              (_illustStore.state == 0)) {
+                            saveStore.saveImage(_illustStore.illusts!);
+                          }
+                          // TODO: 添加配置项 开关和过滤器
+                          final List<String>? tags;
+                          if (userSetting.autoTagWhenStar) {
+                            final filters = [RegExp(r"\d+users入り")];
+                            tags = _illustStore.illusts!.tags
+                                .map((tag) => tag.name)
+                                .where(
+                                  (tag) => !filters.any(
+                                    (regex) => regex.hasMatch(tag),
+                                  ),
+                                )
+                                .toList();
+                          } else {
+                            tags = null;
+                          }
+                          bool success = await _illustStore.star(
+                            restrict: userSetting.defaultPrivateLike
+                                ? "private"
+                                : "public",
+                            tags: tags,
                           );
-                        }
-                      }
-                    },
-                    child: Observer(
-                      builder: (_) {
-                        return StarIcon(state: _illustStore.state);
-                      },
-                    ),
-                  ),
-                );
-              },
-            ),
-          ),
-          body: Observer(
-            builder: (_) {
-              final banWidget = banLogic(context);
-              if (banWidget != null) {
-                return banWidget;
-              }
-              return Container(
-                child: Stack(
-                  children: [
-                    _buildContent(context, _illustStore.illusts),
-                    _buildAppbar(),
-                  ],
+                          if (success && userSetting.followAfterStar) {
+                            bool followSuccess = await _illustStore
+                                .followAfterStar();
+                            if (followSuccess) {
+                              userStore?.isFollow = true;
+                              BotToast.showText(
+                                text:
+                                    "${_illustStore.illusts!.user.name} ${I18n.of(context).followed}",
+                              );
+                            }
+                          }
+                        },
+                        icon: Observer(
+                          builder: (_) {
+                            return StarIcon(state: _illustStore.state);
+                          },
+                        ),
+                      ),
+                    );
+                  },
                 ),
-              );
-            },
-          ),
+              ),
+              body: Observer(
+                builder: (_) {
+                  final banWidget = banLogic(context);
+                  if (banWidget != null) {
+                    return banWidget;
+                  }
+                  return Container(
+                    child: Stack(
+                      children: [
+                        _buildContent(context, _illustStore.illusts),
+                        _buildAppbar(),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            );
+          },
         ),
       ),
     );
@@ -1326,7 +1335,11 @@ class _IllustVerticalPageState extends State<IllustVerticalPage>
       if (userSetting.saveAfterStar && (_illustStore.state == 0)) {
         saveStore.saveImage(_illustStore.illusts!);
       }
-      bool success = await _illustStore.star(restrict: restrict, tags: tags, force: true);
+      bool success = await _illustStore.star(
+        restrict: restrict,
+        tags: tags,
+        force: true,
+      );
       if (success && userSetting.followAfterStar) {
         await _illustStore.followAfterStar();
       }

--- a/lib/page/picture/illust_row_page.dart
+++ b/lib/page/picture/illust_row_page.dart
@@ -21,6 +21,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:pixez/component/ban_page.dart';
 import 'package:pixez/component/common_back_area.dart';
+import 'package:pixez/component/detail_favorite_button.dart';
 import 'package:pixez/component/null_hero.dart';
 import 'package:pixez/component/painter_avatar.dart';
 import 'package:pixez/component/pixiv_image.dart';
@@ -166,100 +167,105 @@ class _IllustRowPageState extends State<IllustRowPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Scaffold(
-      extendBody: true,
-      // appBar: AppBar(
-      //   elevation: 0.0,
-      //   // iconTheme: IconTheme.of(context).copyWith(color: Theme.of(context).textTheme!.bodyText1!.color),
-      //   backgroundColor: Colors.transparent,
-      //   actions: [
-      //     IconButton(
-      //         icon: Icon(Icons.more_vert),
-      //         onPressed: () {
-      //           buildShowModalBottomSheet(context, _illustStore.illusts!);
-      //         })
-      //   ],
-      // ),
-      extendBodyBehindAppBar: true,
-      floatingActionButton: GestureDetector(
-        onLongPress: () {
-          _showBookMarkTag();
-        },
-        onHorizontalDragEnd: (details) {
-          if (widget.onHorizontalDragEnd != null) {
-            widget.onHorizontalDragEnd!(details);
-          }
-        },
-        child: Observer(
-          builder: (context) {
-            return Visibility(
-              visible: _illustStore.errorMessage == null,
-              child: FloatingActionButton(
-                heroTag: widget.id,
-                backgroundColor: Colors.white,
-                onPressed: () => _illustStore.star(),
-                child: Observer(
-                  builder: (_) {
-                    return StarIcon(state: _illustStore.state);
-                  },
-                ),
-              ),
-            );
-          },
-        ),
-      ),
-      body: Observer(
-        builder: (_) {
-          if (!tempView)
-            for (var i in muteStore.banillusts) {
-              if (i.illustId == widget.id.toString()) {
-                return BanPage(
-                  name: "${I18n.of(context).illust}\n${i.name}\n",
-                  onPressed: () {
-                    setState(() {
-                      tempView = true;
-                    });
-                  },
+    return Observer(
+      builder: (_) {
+        return Scaffold(
+          extendBody: true,
+          // appBar: AppBar(
+          //   elevation: 0.0,
+          //   // iconTheme: IconTheme.of(context).copyWith(color: Theme.of(context).textTheme!.bodyText1!.color),
+          //   backgroundColor: Colors.transparent,
+          //   actions: [
+          //     IconButton(
+          //         icon: Icon(Icons.more_vert),
+          //         onPressed: () {
+          //           buildShowModalBottomSheet(context, _illustStore.illusts!);
+          //         })
+          //   ],
+          // ),
+          extendBodyBehindAppBar: true,
+          floatingActionButtonLocation: userSetting.detailFavoriteFabLocation(),
+          floatingActionButton: GestureDetector(
+            onLongPress: () {
+              _showBookMarkTag();
+            },
+            onHorizontalDragEnd: (details) {
+              if (widget.onHorizontalDragEnd != null) {
+                widget.onHorizontalDragEnd!(details);
+              }
+            },
+            child: Observer(
+              builder: (context) {
+                return Visibility(
+                  visible: _illustStore.errorMessage == null,
+                  child: DetailFavoriteButton(
+                    heroTag: widget.id,
+                    backgroundColor: Colors.white,
+                    onPressed: () => _illustStore.star(),
+                    icon: Observer(
+                      builder: (_) {
+                        return StarIcon(state: _illustStore.state);
+                      },
+                    ),
+                  ),
                 );
-              }
-            }
-          if (!tempView && _illustStore.illusts != null) {
-            for (var j in muteStore.banUserIds) {
-              if (j.userId == _illustStore.illusts!.user.id.toString()) {
-                return BanPage(
-                  name: "${I18n.of(context).painter}\n${j.name}\n",
-                  onPressed: () {
-                    setState(() {
-                      tempView = true;
-                    });
-                  },
-                );
-              }
-            }
-            for (var t in muteStore.banTags) {
-              for (var t1 in _illustStore.illusts!.tags) {
-                if (t.name == t1.name)
-                  return BanPage(
-                    name: "${I18n.of(context).tag}\n${t.name}\n",
-                    onPressed: () {
-                      setState(() {
-                        tempView = true;
-                      });
-                    },
-                  );
-              }
-            }
-          }
-          return Container(
-            child: Stack(
-              children: [
-                _buildContent(context, _illustStore.illusts),
-                _buildAppbar(),
-              ],
+              },
             ),
-          );
-        },
-      ),
+          ),
+          body: Observer(
+            builder: (_) {
+              if (!tempView)
+                for (var i in muteStore.banillusts) {
+                  if (i.illustId == widget.id.toString()) {
+                    return BanPage(
+                      name: "${I18n.of(context).illust}\n${i.name}\n",
+                      onPressed: () {
+                        setState(() {
+                          tempView = true;
+                        });
+                      },
+                    );
+                  }
+                }
+              if (!tempView && _illustStore.illusts != null) {
+                for (var j in muteStore.banUserIds) {
+                  if (j.userId == _illustStore.illusts!.user.id.toString()) {
+                    return BanPage(
+                      name: "${I18n.of(context).painter}\n${j.name}\n",
+                      onPressed: () {
+                        setState(() {
+                          tempView = true;
+                        });
+                      },
+                    );
+                  }
+                }
+                for (var t in muteStore.banTags) {
+                  for (var t1 in _illustStore.illusts!.tags) {
+                    if (t.name == t1.name)
+                      return BanPage(
+                        name: "${I18n.of(context).tag}\n${t.name}\n",
+                        onPressed: () {
+                          setState(() {
+                            tempView = true;
+                          });
+                        },
+                      );
+                  }
+                }
+              }
+              return Container(
+                child: Stack(
+                  children: [
+                    _buildContent(context, _illustStore.illusts),
+                    _buildAppbar(),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 

--- a/lib/store/detail_favorite_button_position.dart
+++ b/lib/store/detail_favorite_button_position.dart
@@ -1,0 +1,18 @@
+enum DetailFavoriteButtonPosition {
+  right(0),
+  left(1),
+  custom(2);
+
+  const DetailFavoriteButtonPosition(this.value);
+
+  final int value;
+
+  static DetailFavoriteButtonPosition fromValue(int? storedValue) {
+    if (storedValue != null) {
+      for (final value in values) {
+        if (value.value == storedValue) return value;
+      }
+    }
+    return right;
+  }
+}

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -32,6 +32,7 @@ import 'package:pixez/network/network_mode.dart';
 import 'package:pixez/network/oauth_client.dart';
 import 'package:pixez/page/about/languages.dart';
 import 'package:pixez/secure_plugin.dart';
+import 'package:pixez/store/detail_favorite_button_position.dart';
 import 'package:pixez/store/welcome_page_type.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -97,11 +98,23 @@ abstract class _UserSetting with Store {
   static const String IGNORE_UPDATE_VERSION_KEY = "ignore_update_version";
   static const String ILLUST_DETAIL_SAVE_SKIP_LONG_PRESS_KEY =
       "illust_detail_save_skip_long_press";
+  static const String DETAIL_FAVORITE_BUTTON_POSITION_KEY =
+      "detail_favorite_button_position";
+  static const String DETAIL_FAVORITE_BUTTON_CUSTOM_X_KEY =
+      "detail_favorite_button_custom_x";
+  static const String DETAIL_FAVORITE_BUTTON_CUSTOM_Y_KEY =
+      "detail_favorite_button_custom_y";
   static const String DRAG_START_X_KEY = "drag_start_x";
   static const String AUTO_TAG_WHEN_STAR_KEY = "auto_tag_when_star";
-
   @observable
   double dragStartX = 0;
+  @observable
+  DetailFavoriteButtonPosition detailFavoriteButtonPosition =
+      DetailFavoriteButtonPosition.right;
+  @observable
+  double detailFavoriteButtonCustomX = 1.0;
+  @observable
+  double detailFavoriteButtonCustomY = 1.0;
   @observable
   bool illustDetailSaveSkipLongPress = false;
   @observable
@@ -396,6 +409,57 @@ abstract class _UserSetting with Store {
     illustDetailSaveSkipLongPress = v;
   }
 
+  bool get detailFavoriteButtonLeft =>
+      detailFavoriteButtonPosition == DetailFavoriteButtonPosition.left;
+
+  bool get detailFavoriteButtonCustom =>
+      detailFavoriteButtonPosition == DetailFavoriteButtonPosition.custom;
+
+  double get detailFavoriteButtonX {
+    switch (detailFavoriteButtonPosition) {
+      case DetailFavoriteButtonPosition.left:
+        return 0.0;
+      case DetailFavoriteButtonPosition.custom:
+        return detailFavoriteButtonCustomX;
+      case DetailFavoriteButtonPosition.right:
+        return 1.0;
+    }
+  }
+
+  double get detailFavoriteButtonY {
+    switch (detailFavoriteButtonPosition) {
+      case DetailFavoriteButtonPosition.custom:
+        return detailFavoriteButtonCustomY;
+      case DetailFavoriteButtonPosition.left:
+      case DetailFavoriteButtonPosition.right:
+        return 1.0;
+    }
+  }
+
+  double _normalizePercent(double? value, {double fallback = 1.0}) {
+    return min(1.0, max(0.0, value ?? fallback));
+  }
+
+  @action
+  setDetailFavoriteButtonPosition(DetailFavoriteButtonPosition position) async {
+    detailFavoriteButtonPosition = position;
+    await prefs.setInt(DETAIL_FAVORITE_BUTTON_POSITION_KEY, position.value);
+  }
+
+  @action
+  setDetailFavoriteButtonCustomX(double value) async {
+    final position = _normalizePercent(value);
+    detailFavoriteButtonCustomX = position;
+    await prefs.setDouble(DETAIL_FAVORITE_BUTTON_CUSTOM_X_KEY, position);
+  }
+
+  @action
+  setDetailFavoriteButtonCustomY(double value) async {
+    final position = _normalizePercent(value);
+    detailFavoriteButtonCustomY = position;
+    await prefs.setDouble(DETAIL_FAVORITE_BUTTON_CUSTOM_Y_KEY, position);
+  }
+
   @action
   setAutoTagWhenStar(bool v) async {
     await prefs.setBool(AUTO_TAG_WHEN_STAR_KEY, v);
@@ -576,6 +640,15 @@ abstract class _UserSetting with Store {
     dragStartX = prefs.getDouble(DRAG_START_X_KEY) ?? 0;
     autoTagWhenStar = prefs.getBool(AUTO_TAG_WHEN_STAR_KEY) ?? false;
     ignoreUpdateVersion = prefs.getString(IGNORE_UPDATE_VERSION_KEY);
+    detailFavoriteButtonPosition = DetailFavoriteButtonPosition.fromValue(
+      prefs.getInt(DETAIL_FAVORITE_BUTTON_POSITION_KEY),
+    );
+    detailFavoriteButtonCustomX = _normalizePercent(
+      prefs.getDouble(DETAIL_FAVORITE_BUTTON_CUSTOM_X_KEY),
+    );
+    detailFavoriteButtonCustomY = _normalizePercent(
+      prefs.getDouble(DETAIL_FAVORITE_BUTTON_CUSTOM_Y_KEY),
+    );
     illustDetailSaveSkipLongPress =
         prefs.getBool(ILLUST_DETAIL_SAVE_SKIP_LONG_PRESS_KEY) ?? false;
     if (Platform.isAndroid) {


### PR DESCRIPTION
## 变更

- 在设置页新增详情页收藏按钮位置配置，默认右侧，可选择右侧、左侧或自定义。
- 使用 `DetailFavoriteButtonPosition` 枚举管理收藏按钮位置配置，并以整数值持久化，便于后续扩展。
- Material / Fluent 详情页均支持根据配置调整收藏按钮位置：
  - 右侧：保持原有默认位置；
  - 左侧：将收藏按钮固定到左下角；
  - 自定义：按用户保存的坐标显示收藏按钮。
- 新增 Material / Fluent 自定义位置预览页，预览内容贴近真实详情页布局。
- 自定义预览页支持直接拖动收藏按钮实时调整位置，并在拖动结束或退出预览页时保存坐标。
- 抽出 Material / Fluent 详情页收藏按钮组件，并将位置计算逻辑放在对应组件扩展中，避免设置 store 混入 UI 布局逻辑。
- 复用 `StarIcon` 作为收藏按钮图标，并保持设置页入口图标尺寸与现有样式一致。
- 补齐相关多语言文案，保持多 key 写法以符合现有项目风格。

## 影响

- 用户可以根据阅读习惯调整详情页收藏按钮位置。
- 默认配置仍为右侧，未修改设置时体验与原来保持一致。
- 自定义位置会保存为百分比坐标，适配不同屏幕尺寸下的详情页布局。
- Material 和 Fluent 两套界面均覆盖该配置。

## 验证

- `flutter gen-l10n`
- `dart format` 相关变更文件
- `dart analyze` 相关变更文件通过
- `git diff --check` 通过
