### PR TITLE
fix(user): 移除 TabBar 中的 GestureDetector 解决 Tab 切换 300ms 延迟问题 (remove GestureDetector from Tab items to eliminate 300ms switching latency on user page)

### DIFF
--- a/lib/page/novel/user/novel_users_page.dart
+++ b/lib/page/novel/user/novel_users_page.dart
@@ -48,7 +48,6 @@ class NovelUsersPage extends StatefulWidget {
 class _NovelUsersPageState extends State<NovelUsersPage>
     with TickerProviderStateMixin {
   late TabController _tabController;
-  int _tabIndex = 0;
   late UserStore userStore;
   late ScrollController _scrollController;
   late NovelLightingStore _bookMarkStore;
@@ -180,30 +179,20 @@ class _NovelUsersPageState extends State<NovelUsersPage>
               controller: _tabController,
               onTap: (index) {
                 HapticUtil.selectionClick();
-                setState(() {
-                  _tabIndex = index;
-                });
+                if (_tabController.index == index &&
+                    _scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0,
+                    duration: const Duration(milliseconds: 300),
+                    curve: Curves.easeOut,
+                  );
+                }
               },
               indicatorSize: TabBarIndicatorSize.label,
               tabs: [
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 0) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).works),
-                ),
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 1) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).bookmark),
-                ),
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 2) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).user_page_info_title),
-                ),
+                Tab(text: I18n.of(context).works),
+                Tab(text: I18n.of(context).bookmark),
+                Tab(text: I18n.of(context).user_page_info_title),
               ],
             ),
           ),

--- a/lib/page/user/users_page.dart
+++ b/lib/page/user/users_page.dart
@@ -124,8 +124,6 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
     super.dispose();
   }
 
-  int _tabIndex = 0;
-
   @override
   Widget build(BuildContext context) {
     return Observer(
@@ -335,29 +333,19 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
               controller: _tabController,
               onTap: (index) {
                 HapticUtil.selectionClick();
-                setState(() {
-                  _tabIndex = index;
-                });
+                if (_tabController.index == index &&
+                    _scrollController.hasClients) {
+                  _scrollController.animateTo(
+                    0,
+                    duration: const Duration(milliseconds: 300),
+                    curve: Curves.easeOut,
+                  );
+                }
               },
               tabs: [
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 0) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).works),
-                ),
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 1) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).bookmark),
-                ),
-                GestureDetector(
-                  onDoubleTap: () {
-                    if (_tabIndex == 2) _scrollController.position.jumpTo(0);
-                  },
-                  child: Tab(text: I18n.of(context).user_page_info_title),
-                ),
+                Tab(text: I18n.of(context).works),
+                Tab(text: I18n.of(context).bookmark),
+                Tab(text: I18n.of(context).user_page_info_title),
               ],
             ),
           ),


### PR DESCRIPTION
老大，一个体验优化的小改，你看看要不要并：
移除作者页 Tab 外层包裹的 GestureDetector 以消除双击判定导致的 300ms 切换延迟，并将点击已激活 Tab 回到顶部逻辑平滑移至 TabBar.onTap