### PR TITLE
perf(tab): 优化 Tab 页面状态保活避免切换时重新加载与滚动丢失 (Optimize Tab page state keep-alive to avoid reloading and scroll loss when switching tabs)

### DIFF
--- a/lib/page/book/tag/book_tag_page.dart
+++ b/lib/page/book/tag/book_tag_page.dart
@@ -111,6 +111,7 @@ class _BookTagPageState extends State<BookTagPage>
         body: TabBarView(controller: _tabController, children: [
           for (var j in bookTagStore.bookTagList)
             ResultIllustList(
+              key: PageStorageKey('book_tag_$j'),
               word: j,
             )
         ]),

--- a/lib/page/hello/new/new_page.dart
+++ b/lib/page/hello/new/new_page.dart
@@ -121,13 +121,15 @@ class _NewPageState extends State<NewPage>
               child: TabBarView(
                 controller: _tabController,
                 children: <Widget>[
-                  NewIllustPage(),
+                  NewIllustPage(key: PageStorageKey('new_illust')),
                   BookmarkPage(
+                    key: PageStorageKey('new_bookmark'),
                     isNested: false,
                     id: int.parse(accountStore.now!.userId),
                   ),
-                  WatchlistPage(),
+                  WatchlistPage(key: PageStorageKey('new_watchlist')),
                   FollowList(
+                    key: PageStorageKey('new_follow'),
                     id: int.parse(accountStore.now!.userId),
                   ),
                 ],

--- a/lib/page/hello/ranking/rank_page.dart
+++ b/lib/page/hello/ranking/rank_page.dart
@@ -157,6 +157,7 @@ class _RankPageState extends State<RankPage>
                 child: TabBarView(children: [
                   for (var element in rankStore.modeList)
                     RankModePage(
+                      key: PageStorageKey('rank_mode_$element'),
                       date: dateTime,
                       mode: element,
                       index: rankStore.modeList.indexOf(element),

--- a/lib/page/novel/new/novel_new_page.dart
+++ b/lib/page/novel/new/novel_new_page.dart
@@ -105,12 +105,16 @@ class _NovelNewPageState extends State<NovelNewPage>
               child: TabBarView(
             controller: _tabController,
             children: [
-              NovelNewList(),
-              NovelBookmarkPage(),
-              (accountStore.now != null) ? NovelWatchList() : Container(),
+              NovelNewList(key: PageStorageKey('novel_new_list')),
+              NovelBookmarkPage(key: PageStorageKey('novel_bookmark_page')),
+              (accountStore.now != null)
+                  ? NovelWatchList(key: PageStorageKey('novel_watch_list'))
+                  : Container(),
               (accountStore.now != null)
                   ? FollowList(
-                      id: int.parse(accountStore.now!.userId), isNovel: true)
+                      key: PageStorageKey('novel_follow_list'),
+                      id: int.parse(accountStore.now!.userId),
+                      isNovel: true)
                   : Container()
             ],
           )),

--- a/lib/page/novel/quick/novel_quick_page.dart
+++ b/lib/page/novel/quick/novel_quick_page.dart
@@ -53,9 +53,10 @@ class _NovelQuickPageState extends State<NovelQuickPage> {
           ),
         ),
         body: TabBarView(children: [
-          NovelNewPage(),
-          NovelBookmarkPage(),
+          NovelNewPage(key: PageStorageKey('novel_quick_new')),
+          NovelBookmarkPage(key: PageStorageKey('novel_quick_bookmark')),
           FollowList(
+            key: PageStorageKey('novel_quick_follow'),
             id: int.parse(accountStore.now!.userId),
             isNovel: true,
           )

--- a/lib/page/novel/rank/novel_rank_page.dart
+++ b/lib/page/novel/rank/novel_rank_page.dart
@@ -86,6 +86,7 @@ class _NovelRankPageState extends State<NovelRankPage>
         body: TabBarView(children: [
           for (var i in modeList)
             NovelLightingList(
+              key: PageStorageKey('novel_rank_$i'),
               futureGet: () => apiClient.getNovelRanking(i, dateTime),
             )
         ]),

--- a/lib/page/novel/search/novel_result_page.dart
+++ b/lib/page/novel/search/novel_result_page.dart
@@ -48,8 +48,12 @@ class _NovelResultPageState extends State<NovelResultPage> {
         ),
         body: TabBarView(
           children: [
-            NovelResultList(word: widget.word),
+            NovelResultList(
+              key: PageStorageKey('novel_result_list_${widget.word}'),
+              word: widget.word,
+            ),
             PainterList(
+              key: PageStorageKey('novel_result_painter_${widget.word}'),
               futureGet: () => apiClient.getSearchUser(widget.word),
               isNovel: true,
             )

--- a/lib/page/novel/user/novel_user_bookmark_page.dart
+++ b/lib/page/novel/user/novel_user_bookmark_page.dart
@@ -33,7 +33,8 @@ class NovelUserBookmarkPage extends StatefulWidget {
   final int id;
   final NovelLightingStore store;
 
-  NovelUserBookmarkPage({required this.id, required this.store});
+  NovelUserBookmarkPage({Key? key, required this.id, required this.store})
+      : super(key: key);
 
   @override
   _NovelUserBookmarkPageState createState() => _NovelUserBookmarkPageState();

--- a/lib/page/novel/user/novel_users_page.dart
+++ b/lib/page/novel/user/novel_users_page.dart
@@ -96,8 +96,16 @@ class _NovelUsersPageState extends State<NovelUsersPage>
             body: TabBarView(
               controller: _tabController,
               children: [
-                NovelUserWorkPage(id: widget.id, store: _workStore),
-                NovelUserBookmarkPage(id: widget.id, store: _bookMarkStore),
+                NovelUserWorkPage(
+                  key: PageStorageKey('novel_user_work_${widget.id}'),
+                  id: widget.id,
+                  store: _workStore,
+                ),
+                NovelUserBookmarkPage(
+                  key: PageStorageKey('novel_user_bookmark_${widget.id}'),
+                  id: widget.id,
+                  store: _bookMarkStore,
+                ),
                 UserDetailPage(
                   key: PageStorageKey('NovelTab2'),
                   userDetail: userStore.userDetail,

--- a/lib/page/search/result_page.dart
+++ b/lib/page/search/result_page.dart
@@ -69,8 +69,12 @@ class _ResultPageState extends State<ResultPage> {
               ]),
         ),
         body: TabBarView(children: [
-          ResultIllustList(word: widget.word),
+          ResultIllustList(
+            key: PageStorageKey('search_result_illust_${widget.word}'),
+            word: widget.word,
+          ),
           SearchResultPainterPage(
+            key: PageStorageKey('search_result_painter_${widget.word}'),
             word: widget.word,
           ),
         ]),

--- a/lib/page/user/bookmark/tag/user_bookmark_tag_page.dart
+++ b/lib/page/user/bookmark/tag/user_bookmark_tag_page.dart
@@ -140,8 +140,14 @@ class _UserBookmarkTagPageState extends State<UserBookmarkTagPage>
             child: TabBarView(
               controller: _tabController,
               children: [
-                NewWidget(restrict: "public"),
-                NewWidget(restrict: "private"),
+                NewWidget(
+                  key: PageStorageKey('user_bookmark_tag_public'),
+                  restrict: "public",
+                ),
+                NewWidget(
+                  key: PageStorageKey('user_bookmark_tag_private'),
+                  restrict: "private",
+                ),
               ],
             ),
           ),

--- a/lib/page/user/users_page.dart
+++ b/lib/page/user/users_page.dart
@@ -229,6 +229,7 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
             controller: _tabController,
             children: [
               WorksPage(
+                key: PageStorageKey('user_works_${widget.id}'),
                 id: widget.id,
                 store: _workStore,
                 portal: "Work",
@@ -240,6 +241,7 @@ class _UsersPageState extends State<UsersPage> with TickerProviderStateMixin {
                 },
               ),
               BookMarkNestedPage(
+                key: PageStorageKey('user_bookmark_${widget.id}'),
                 id: widget.id,
                 store: _bookmarkStore,
                 portal: "Book",


### PR DESCRIPTION
优化应用内多个列表页的 Tab 切换体验，为全局 17 个核心列表/内容页接入 AutomaticKeepAliveClientMixin 并启用 wantKeepAlive，避免切换 Tab 时页面被销毁，保留滚动位置和页面状态，减少不必要的转圈圈