### PR TITLE
feat(search): 添加投稿时间快速范围选择

### DIFF
--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -352,5 +352,12 @@
   "network_mode_standard": "Standardverbindung",
   "network_mode_standard_message": "Für die meisten Netzwerke empfohlen.",
   "ignore_current_version_update": "Aktuelles Update ignorieren",
-  "haptic_feedback": "Haptisches Feedback"
+  "haptic_feedback": "Haptisches Feedback",
+  "date_preset_none": "Beliebig",
+  "date_preset_1day": "1 Tag",
+  "date_preset_1week": "1 Woche",
+  "date_preset_1month": "1 Monat",
+  "date_preset_6months": "6 Monate",
+  "date_preset_1year": "1 Jahr",
+  "date_preset_custom": "Zeitraum auswählen"
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -351,5 +351,12 @@
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
   "ignore_current_version_update": "Ignore current version update",
-  "haptic_feedback": "Haptic feedback"
+  "haptic_feedback": "Haptic feedback",
+  "date_preset_none": "All time",
+  "date_preset_1day": "1 day",
+  "date_preset_1week": "1 week",
+  "date_preset_1month": "1 month",
+  "date_preset_6months": "6 months",
+  "date_preset_1year": "1 year",
+  "date_preset_custom": "Custom range"
 }

--- a/lib/l10n/intl_en_US.arb
+++ b/lib/l10n/intl_en_US.arb
@@ -352,5 +352,12 @@
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
   "ignore_current_version_update": "Ignore current version update",
-  "haptic_feedback": "Haptic feedback"
+  "haptic_feedback": "Haptic feedback",
+  "date_preset_none": "All time",
+  "date_preset_1day": "1 day",
+  "date_preset_1week": "1 week",
+  "date_preset_1month": "1 month",
+  "date_preset_6months": "6 months",
+  "date_preset_1year": "1 year",
+  "date_preset_custom": "Custom range"
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -341,5 +341,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Sin límite",
+  "date_preset_1day": "1 día",
+  "date_preset_1week": "1 semana",
+  "date_preset_1month": "1 mes",
+  "date_preset_6months": "6 meses",
+  "date_preset_1year": "1 año",
+  "date_preset_custom": "Intervalo personalizado"
 }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Walang limitasyon",
+  "date_preset_1day": "1 araw",
+  "date_preset_1week": "1 linggo",
+  "date_preset_1month": "1 buwan",
+  "date_preset_6months": "6 na buwan",
+  "date_preset_1year": "1 taon",
+  "date_preset_custom": "Pumili ng saklaw ng petsa"
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Semua waktu",
+  "date_preset_1day": "1 hari",
+  "date_preset_1week": "1 minggu",
+  "date_preset_1month": "1 bulan",
+  "date_preset_6months": "6 bulan",
+  "date_preset_1year": "1 tahun",
+  "date_preset_custom": "Rentang khusus"
 }

--- a/lib/l10n/intl_id_ID.arb
+++ b/lib/l10n/intl_id_ID.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Semua waktu",
+  "date_preset_1day": "1 hari",
+  "date_preset_1week": "1 minggu",
+  "date_preset_1month": "1 bulan",
+  "date_preset_6months": "6 bulan",
+  "date_preset_1year": "1 tahun",
+  "date_preset_custom": "Rentang khusus"
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -351,5 +351,12 @@
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
   "ignore_current_version_update": "Ignore current version update",
-  "haptic_feedback": "触覚フィードバック"
+  "haptic_feedback": "触覚フィードバック",
+  "date_preset_none": "指定なし",
+  "date_preset_1day": "1日",
+  "date_preset_1week": "1週間",
+  "date_preset_1month": "1ヶ月",
+  "date_preset_6months": "6ヶ月",
+  "date_preset_1year": "1年",
+  "date_preset_custom": "期間指定"
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "전체",
+  "date_preset_1day": "1일",
+  "date_preset_1week": "1주일",
+  "date_preset_1month": "1개월",
+  "date_preset_6months": "6개월",
+  "date_preset_1year": "1년",
+  "date_preset_custom": "기간 지정"
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "За всё время",
+  "date_preset_1day": "1 день",
+  "date_preset_1week": "1 неделя",
+  "date_preset_1month": "1 месяц",
+  "date_preset_6months": "6 месяцев",
+  "date_preset_1year": "1 год",
+  "date_preset_custom": "Указать период"
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -351,5 +351,12 @@
   "network_mode_ech_message": "Uygulama açıldığı halde sunucu yanıtı başarısız olursa bunu dene.",
   "network_mode_standard": "Standart bağlantı",
   "network_mode_standard_message": "Çoğu ağ için önerilir.",
-  "ignore_current_version_update": "Mevcut sürüm güncellemesini yoksay"
+  "ignore_current_version_update": "Mevcut sürüm güncellemesini yoksay",
+  "date_preset_none": "Tümü",
+  "date_preset_1day": "1 gün",
+  "date_preset_1week": "1 hafta",
+  "date_preset_1month": "1 ay",
+  "date_preset_6months": "6 ay",
+  "date_preset_1year": "1 yıl",
+  "date_preset_custom": "Özel tarih aralığı"
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Không giới hạn",
+  "date_preset_1day": "1 ngày",
+  "date_preset_1week": "1 tuần",
+  "date_preset_1month": "1 tháng",
+  "date_preset_6months": "6 tháng",
+  "date_preset_1year": "1 năm",
+  "date_preset_custom": "Khoảng thời gian tùy chỉnh"
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -350,5 +350,12 @@
   "network_mode_ech_message": "Try this when the app opens but service responses fail.",
   "network_mode_standard": "Standard connection",
   "network_mode_standard_message": "Recommended for most networks.",
-  "ignore_current_version_update": "Ignore current version update"
+  "ignore_current_version_update": "Ignore current version update",
+  "date_preset_none": "Không giới hạn",
+  "date_preset_1day": "1 ngày",
+  "date_preset_1week": "1 tuần",
+  "date_preset_1month": "1 tháng",
+  "date_preset_6months": "6 tháng",
+  "date_preset_1year": "1 năm",
+  "date_preset_custom": "Khoảng thời gian tùy chỉnh"
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -351,5 +351,12 @@
   "network_mode_standard": "标准连接",
   "network_mode_standard_message": "大多数网络环境推荐使用。",
   "ignore_current_version_update": "忽略当前版本更新",
-  "haptic_feedback": "触感反馈"
+  "haptic_feedback": "触感反馈",
+  "date_preset_none": "不限",
+  "date_preset_1day": "1天",
+  "date_preset_1week": "1周",
+  "date_preset_1month": "1个月",
+  "date_preset_6months": "6个月",
+  "date_preset_1year": "1年",
+  "date_preset_custom": "指定期间"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -352,5 +352,12 @@
   "network_mode_standard": "标准连接",
   "network_mode_standard_message": "大多数网络环境推荐使用。",
   "ignore_current_version_update": "忽略当前版本更新",
-  "haptic_feedback": "触感反馈"
+  "haptic_feedback": "触感反馈",
+  "date_preset_none": "不限",
+  "date_preset_1day": "1天",
+  "date_preset_1week": "1周",
+  "date_preset_1month": "1个月",
+  "date_preset_6months": "6个月",
+  "date_preset_1year": "1年",
+  "date_preset_custom": "指定期间"
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -352,5 +352,12 @@
   "network_mode_standard": "標準連線",
   "network_mode_standard_message": "建議大多數網路環境使用。",
   "ignore_current_version_update": "忽略当前版本更新",
-  "haptic_feedback": "觸感回饋"
+  "haptic_feedback": "觸感回饋",
+  "date_preset_none": "不限",
+  "date_preset_1day": "1天",
+  "date_preset_1week": "1週",
+  "date_preset_1month": "1個月",
+  "date_preset_6months": "6個月",
+  "date_preset_1year": "1年",
+  "date_preset_custom": "指定期間"
 }

--- a/lib/page/novel/search/novel_result_list.dart
+++ b/lib/page/novel/search/novel_result_list.dart
@@ -7,6 +7,16 @@ import 'package:pixez/main.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:pixez/page/novel/component/novel_lighting_list.dart';
 
+enum SearchDatePreset {
+  none,
+  day1,
+  week1,
+  month1,
+  month6,
+  year1,
+  custom,
+}
+
 class NovelResultList extends StatefulWidget {
   final String word;
 
@@ -52,11 +62,7 @@ class _NovelResultListState extends State<NovelResultList> {
                 alignment: Alignment.centerRight,
                 child: Row(
                   children: [
-                    IconButton(
-                        icon: Icon(Icons.date_range),
-                        onPressed: () {
-                          _buildShowDateRange(context);
-                        }),
+                    _buildDateRangeButton(),
                     _buildStar(),
                     IconButton(
                         icon: Icon(Icons.filter_alt_outlined),
@@ -101,6 +107,77 @@ class _NovelResultListState extends State<NovelResultList> {
   String searchTarget = search_target[0];
   String selectSort = "date_desc";
   int selectStarNum = 0;
+
+  String _getDatePresetLabel(BuildContext context, SearchDatePreset preset) {
+    return switch (preset) {
+      SearchDatePreset.none => I18n.of(context).date_preset_none,
+      SearchDatePreset.day1 => I18n.of(context).date_preset_1day,
+      SearchDatePreset.week1 => I18n.of(context).date_preset_1week,
+      SearchDatePreset.month1 => I18n.of(context).date_preset_1month,
+      SearchDatePreset.month6 => I18n.of(context).date_preset_6months,
+      SearchDatePreset.year1 => I18n.of(context).date_preset_1year,
+      SearchDatePreset.custom => I18n.of(context).date_preset_custom,
+    };
+  }
+
+  Widget _buildDateRangeButton() {
+    return PopupMenuButton<SearchDatePreset>(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Icon(
+          Icons.date_range,
+          color: _dateTimeRange != null
+              ? Theme.of(context).colorScheme.primary
+              : null,
+        ),
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(16.0)),
+      ),
+      onSelected: (preset) {
+        if (preset == SearchDatePreset.custom) {
+          _buildShowDateRange(context);
+          return;
+        }
+        final now = DateTime.now();
+        setState(() {
+          _dateTimeRange = switch (preset) {
+            SearchDatePreset.none => null,
+            SearchDatePreset.day1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 1)),
+                end: now,
+              ),
+            SearchDatePreset.week1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 7)),
+                end: now,
+              ),
+            SearchDatePreset.month1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 30)),
+                end: now,
+              ),
+            SearchDatePreset.month6 => DateTimeRange(
+                start: now.subtract(const Duration(days: 180)),
+                end: now,
+              ),
+            SearchDatePreset.year1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 365)),
+                end: now,
+              ),
+            SearchDatePreset.custom => _dateTimeRange,
+          };
+        });
+        _changeQueryParams();
+      },
+      itemBuilder: (context) {
+        return SearchDatePreset.values.map((preset) {
+          return PopupMenuItem<SearchDatePreset>(
+            value: preset,
+            child: Text(_getDatePresetLabel(context, preset)),
+          );
+        }).toList();
+      },
+    );
+  }
 
   DateTimeRange? _dateTimeRange;
 

--- a/lib/page/search/result_illust_list.dart
+++ b/lib/page/search/result_illust_list.dart
@@ -33,6 +33,16 @@ enum UgoiraFilter {
   noUgoira,
 }
 
+enum SearchDatePreset {
+  none,
+  day1,
+  week1,
+  month1,
+  month6,
+  year1,
+  custom,
+}
+
 class ResultIllustList extends StatefulWidget {
   final String word;
 
@@ -186,14 +196,7 @@ class _ResultIllustListState extends State<ResultIllustList> {
                       const EdgeInsets.only(top: 8.0, bottom: 8.0, right: 8.0),
                   child: Row(
                     children: [
-                      InkWell(
-                          child: Padding(
-                            padding: const EdgeInsets.all(4.0),
-                            child: Icon(Icons.date_range),
-                          ),
-                          onTap: () {
-                            _buildShowDateRange(context);
-                          }),
+                      _buildDateRangeButton(),
                       if (accountStore.now?.isPremium == 1)
                         Padding(
                           padding: const EdgeInsets.all(4.0),
@@ -233,6 +236,77 @@ class _ResultIllustListState extends State<ResultIllustList> {
                     ))
         ],
       ),
+    );
+  }
+
+  String _getDatePresetLabel(BuildContext context, SearchDatePreset preset) {
+    return switch (preset) {
+      SearchDatePreset.none => I18n.of(context).date_preset_none,
+      SearchDatePreset.day1 => I18n.of(context).date_preset_1day,
+      SearchDatePreset.week1 => I18n.of(context).date_preset_1week,
+      SearchDatePreset.month1 => I18n.of(context).date_preset_1month,
+      SearchDatePreset.month6 => I18n.of(context).date_preset_6months,
+      SearchDatePreset.year1 => I18n.of(context).date_preset_1year,
+      SearchDatePreset.custom => I18n.of(context).date_preset_custom,
+    };
+  }
+
+  Widget _buildDateRangeButton() {
+    return PopupMenuButton<SearchDatePreset>(
+      child: Padding(
+        padding: const EdgeInsets.all(4.0),
+        child: Icon(
+          Icons.date_range,
+          color: _dateTimeRange != null
+              ? Theme.of(context).colorScheme.primary
+              : null,
+        ),
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(16.0)),
+      ),
+      onSelected: (preset) {
+        if (preset == SearchDatePreset.custom) {
+          _buildShowDateRange(context);
+          return;
+        }
+        final now = DateTime.now();
+        setState(() {
+          _dateTimeRange = switch (preset) {
+            SearchDatePreset.none => null,
+            SearchDatePreset.day1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 1)),
+                end: now,
+              ),
+            SearchDatePreset.week1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 7)),
+                end: now,
+              ),
+            SearchDatePreset.month1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 30)),
+                end: now,
+              ),
+            SearchDatePreset.month6 => DateTimeRange(
+                start: now.subtract(const Duration(days: 180)),
+                end: now,
+              ),
+            SearchDatePreset.year1 => DateTimeRange(
+                start: now.subtract(const Duration(days: 365)),
+                end: now,
+              ),
+            SearchDatePreset.custom => _dateTimeRange,
+          };
+        });
+        _changeQueryParams();
+      },
+      itemBuilder: (context) {
+        return SearchDatePreset.values.map((preset) {
+          return PopupMenuItem<SearchDatePreset>(
+            value: preset,
+            child: Text(_getDatePresetLabel(context, preset)),
+          );
+        }).toList();
+      },
     );
   }
 


### PR DESCRIPTION
当前的搜索工具中，点击日期范围按钮会直接打开日期范围选择器。
参考Pixiv官方以及收藏数选择器的设计，为投稿时间新增了一个快捷预设下拉菜单。

### 变更内容

* 将原本直接打开日期选择器的方式替换为 `PopupMenuButton`，提供以下快捷选项：

  * **不限时间**
  * **1 天 / 1 周 / 1 个月 / 6 个月 / 1 年**（根据当前时间计算日期范围）
  * **自定义时间范围**（打开原生的 `showDateRangePicker`）

* 应用于：
  * **插画搜索**（`result_illust_list.dart`）
  * **小说搜索**（`novel_result_list.dart`）
* 在 `lib/l10n/*.arb` 中完成国际化（除中英语外均为Chatgpt翻译）
* 没有实现持久化，每次进行新的搜索时，日期筛选始终默认为**不限时间**

_Android模拟器以及实体机测试功能正常，ios设备没有测试过_
### Screenshots
<img width="672" height="1046" alt="image" src="https://github.com/user-attachments/assets/7ed94eea-34c5-4069-9916-1ae75bbe2b06" />

