### PR TITLE
搜索「users入り」收藏数筛选增加 100000 档 (#1036)

### DIFF
--- a/lib/fluent/page/search/result_illust_list.dart
+++ b/lib/fluent/page/search/result_illust_list.dart
@@ -71,6 +71,7 @@ class _ResultIllustListState extends State<ResultIllustList> {
     20000,
     30000,
     50000,
+    100000,
   ];
 
   final sort = [

--- a/lib/page/novel/search/novel_result_list.dart
+++ b/lib/page/novel/search/novel_result_list.dart
@@ -89,6 +89,7 @@ class _NovelResultListState extends State<NovelResultList> {
     20000,
     30000,
     50000,
+    100000,
   ];
 
   final sort = ["date_desc", "date_asc", "popular_desc"];

--- a/lib/page/search/result_illust_list.dart
+++ b/lib/page/search/result_illust_list.dart
@@ -76,6 +76,7 @@ class _ResultIllustListState extends State<ResultIllustList> {
     20000,
     30000,
     50000,
+    100000,
   ];
   List<List<int>> premiumStarNum = [
     [],


### PR DESCRIPTION
Closes #1036

## 改动
「收藏数 users入り」筛选菜单原本最大只到 50000，热门标签下 `100000users入り` 的作品不少，筛不出来。
在三处搜索页的 `starNum` 列表末尾追加 `100000`：

- `lib/page/search/result_illust_list.dart`（插画）
- `lib/page/novel/search/novel_result_list.dart`（小说）
- `lib/fluent/page/search/result_illust_list.dart`（Fluent / Windows）

三处对 `starNum` 都是按值使用（`_starValue = value` 拼进搜索词），菜单由 `map` 动态生成，不涉及索引持久化，加一项对旁路无影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)