### PR TITLE
fix(download): correct zero-based task pagination offset

### DIFF
--- a/lib/models/task_persist.dart
+++ b/lib/models/task_persist.dart
@@ -240,7 +240,7 @@ create table $tableAccount (
       ],
       orderBy: "${columnId} ${asc ? "ASC" : "DESC"}",
       limit: LIMIT,
-      offset: (page - 1) * LIMIT,
+      offset: page * LIMIT,
       where: status == 10 ? null : '$columnStatus = ?',
       whereArgs: status == 10 ? null : [status],
     );


### PR DESCRIPTION
Fixes #1291

任务页（Material / Fluent）的 `_page` 从 `0` 开始，但 `TaskPersistProvider.getDownloadTask` 用 `(page - 1) * LIMIT` 计算 offset：

- 第 0 页 offset 为 `-16`，SQLite 按 `0` 处理
- 第 1 页 offset 也是 `0`

于是首批 16 条记录被追加了两次，即 issue 里「列表前半段整体重复一次」的现象。

改为 `page * LIMIT`，与调用方的零基页码约定保持一致；两个任务页面不需要改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnkVcAvni7rtMty2AYDBnf