### PR TITLE
fix(novel): honor default private bookmark preference

### DIFF
--- a/lib/page/novel/component/novel_bookmark_button.dart
+++ b/lib/page/novel/component/novel_bookmark_button.dart
@@ -15,6 +15,7 @@
  */
 
 import 'package:material_ui/material_ui.dart';
+import 'package:pixez/main.dart';
 import 'package:pixez/models/novel_recom_response.dart';
 import 'package:pixez/network/api_client.dart';
 import 'package:pixez/utils/haptic_util.dart';
@@ -60,7 +61,8 @@ class _NovelBookmarkButtonState extends State<NovelBookmarkButton> {
         onPressed: () async {
           if (!widget.novel.isBookmarked) {
             try {
-              await apiClient.postNovelBookmarkAdd(widget.novel.id, "public");
+              await apiClient.postNovelBookmarkAdd(widget.novel.id,
+                  userSetting.defaultPrivateLike ? "private" : "public");
               HapticUtil.medium();
               setState(() {
                 widget.novel.isBookmarked = true;


### PR DESCRIPTION
Fixes #1014

插画收藏已经按 `userSetting.defaultPrivateLike` 决定 `private` / `public`，但 `NovelBookmarkButton` 普通点击时硬编码为 `"public"`，导致「默认私密收藏」对小说无效。

改为与插画收藏一致的判断。长按仍然是明确的私密收藏，取消收藏不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnkVcAvni7rtMty2AYDBnf