### PR TITLE
fix(viewer): respect disabled artwork swipe on nested gestures

### DIFF
--- a/lib/page/picture/picture_list_page.dart
+++ b/lib/page/picture/picture_list_page.dart
@@ -117,6 +117,7 @@ class _PictureListPageState extends State<PictureListPage> {
   }
 
   _onDrag(DragEndDetails details) {
+    if (!userSetting.swipeChangeArtwork) return;
     final pixelsPerSecond = details.velocity.pixelsPerSecond;
     if (pixelsPerSecond.dy.abs() > pixelsPerSecond.dx.abs()) return;
     if (pixelsPerSecond.dx.abs() > screenWidth) {


### PR DESCRIPTION
Fixes #668

关闭「横向滑动切换作品」后，`PictureListPage` 给 `PageView` 用了 `NeverScrollableScrollPhysics`，普通区域已经不能切换；但 `IllustLightingPage` / `IllustRowPage` 里右下角收藏按钮外层的 `GestureDetector` 仍然把 `onHorizontalDragEnd` 转给 `PictureListPage._onDrag`，所以从那个区域横划依旧能切换作品。

在 `_onDrag` 入口统一检查 `userSetting.swipeChangeArtwork`，开关关闭时直接返回，不再依赖每个子组件各自判断。开关开启时行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnkVcAvni7rtMty2AYDBnf