### PR TITLE
fix(settings): separate portrait and landscape adaptive columns

### DIFF
--- a/lib/fluent/lighting/fluent_lighting_page.dart
+++ b/lib/fluent/lighting/fluent_lighting_page.dart
@@ -284,7 +284,9 @@ class _LightingListState extends State<LightingList> {
 
   SliverWaterfallFlowDelegate _buildGridDelegate() {
     var count = 2;
-    if (userSetting.crossAdapt) {
+    if (MediaQuery.of(context).orientation == Orientation.portrait
+        ? userSetting.crossAdapt
+        : userSetting.hCrossAdapt) {
       count = _buildSliderValue();
     } else {
       count = (MediaQuery.of(context).orientation == Orientation.portrait)

--- a/lib/fluent/page/hello/setting/setting_quality_page.dart
+++ b/lib/fluent/page/hello/setting/setting_quality_page.dart
@@ -345,6 +345,7 @@ class _SettingQualityPageState extends State<SettingQualityPage>
                             );
                             return;
                           }
+                          await userSetting.setHCrossAdapt(false);
                           userSetting.setHCrossCount(index! + 2);
                           BotToast.showText(
                             text: I18n.of(context).need_to_restart_app,

--- a/lib/lighting/lighting_page.dart
+++ b/lib/lighting/lighting_page.dart
@@ -309,7 +309,9 @@ class _LightingListState extends State<LightingList> {
 
   SliverWaterfallFlowDelegate _buildGridDelegate() {
     var count = 2;
-    if (userSetting.crossAdapt) {
+    if (MediaQuery.of(context).orientation == Orientation.portrait
+        ? userSetting.crossAdapt
+        : userSetting.hCrossAdapt) {
       count = _buildSliderValue();
     } else {
       count = (MediaQuery.of(context).orientation == Orientation.portrait)

--- a/lib/page/hello/setting/setting_quality_page.dart
+++ b/lib/page/hello/setting/setting_quality_page.dart
@@ -255,6 +255,7 @@ class _SettingQualityPageState extends State<SettingQualityPage>
                         Leader.push(context, SettingCrossAdpaterPage(h: true));
                         return;
                       }
+                      await userSetting.setHCrossAdapt(false);
                       userSetting.setHCrossCount(index + 2);
                       BotToast.showText(
                         text: I18n.of(context).need_to_restart_app,

--- a/lib/store/user_setting.dart
+++ b/lib/store/user_setting.dart
@@ -84,8 +84,8 @@ abstract class _UserSetting with Store {
   static const String NAME_EVAL_KEY = "name_eval";
   static const String CROSS_ADAPT_KEY = "cross_adapt";
   static const String CROSS_ADAPT_WIDTH_KEY = "cross_adapt_width";
-  static const String H_CROSS_ADAPT_KEY = "cross_adapt";
-  static const String H_CROSS_ADAPT_WIDTH_KEY = "cross_adapt_width";
+  static const String H_CROSS_ADAPT_KEY = "h_cross_adapt";
+  static const String H_CROSS_ADAPT_WIDTH_KEY = "h_cross_adapt_width";
   static const String DEFAULT_PRIVATE_LIKE_KEY = "default_private_like";
   static const String IMAGE_PICKER_TYPE_KEY = "image_picker_type_renew";
   static const String LONG_PRESS_SAVE_CONFIRM_KEY = "long_press_save_confirm";
@@ -462,11 +462,11 @@ abstract class _UserSetting with Store {
         ApiClient.Accept_Language;
     locale = iSupportedLocales[languageNum];
     crossAdapt = prefs.getBool(CROSS_ADAPT_KEY) ?? false;
-    hCrossAdapt = prefs.getBool(CROSS_ADAPT_KEY) ?? false;
+    hCrossAdapt = prefs.getBool(H_CROSS_ADAPT_KEY) ?? false;
     final crossAdapterV = prefs.getInt(CROSS_ADAPT_WIDTH_KEY) ?? 100;
     final hCrossAdapterV = prefs.getInt(H_CROSS_ADAPT_WIDTH_KEY) ?? 100;
-    crossAdapterWidth = min(2160, max(100, crossAdapterV));
-    hCrossAdapterWidth = min(2160, max(100, hCrossAdapterV));
+    crossAdapterWidth = min(2160, max(50, crossAdapterV));
+    hCrossAdapterWidth = min(2160, max(50, hCrossAdapterV));
     crossCount = prefs.getInt(CROSS_COUNT_KEY) ?? 2;
     hCrossCount = prefs.getInt(H_CROSS_COUNT_KEY) ?? 4;
     feedAIBadge = prefs.getBool(FEED_AI_BADGE_KEY) ?? true;


### PR DESCRIPTION
Fixes #1328

Adapt 列数设置有几处互相牵连的问题：

- `H_CROSS_ADAPT_KEY` / `H_CROSS_ADAPT_WIDTH_KEY` 的字符串值与竖屏的 key 完全相同，横屏开关和宽度实际上一直在读写竖屏的存储；恢复时 `hCrossAdapt` 又直接读了 `CROSS_ADAPT_KEY`。现在横屏改用独立的 `h_cross_adapt` / `h_cross_adapt_width`，并从正确的 key 恢复。
- 宽度滑块最小值是 `50`，但启动恢复用了 `max(100, value)`，`50–99` 重启后都会变回 `100`。下限改为与滑块一致的 `50`。
- Material / Fluent 的 `_buildGridDelegate` 只看竖屏的 `crossAdapt`，宽度却按方向分别取值。现在开关也按当前方向选 `crossAdapt` / `hCrossAdapt`。
- 横屏从 Adapt 切回固定列数时没有关掉 `hCrossAdapt`，两个设置页都补上 `setHCrossAdapt(false)`，与竖屏分支一致。

Fluent 里实际适配宽度的 `250` 下限未动。由于横屏改用了新的存储 key，旧用户的横屏 Adapt 设置会回到默认值一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnkVcAvni7rtMty2AYDBnf