### PR TITLE
fix(about_page): fix contributor card alignment & overflow

### DIFF
--- a/lib/fluent/page/about/about_page.dart
+++ b/lib/fluent/page/about/about_page.dart
@@ -326,7 +326,7 @@ class _AboutPageState extends State<AboutPage> {
           ListTile(
             leading: Icon(FluentIcons.favorite_star),
             title: Text(I18n.of(context).thanks),
-            subtitle: Text('感谢帮助我测试的弹幕委员会群友们\n感谢pixiv cat站主提供的图床'),
+            subtitle: Text('感谢帮助我测试的弹幕委员会群友们\n感谢 pixiv cat 站主提供的图床'),
             onPressed: () {
               Leader.push(
                 context,

--- a/lib/page/about/about_page.dart
+++ b/lib/page/about/about_page.dart
@@ -347,7 +347,7 @@ class _AboutPageState extends State<AboutPage> {
             ListTile(
               leading: Icon(Icons.favorite),
               title: Text(I18n.of(context).thanks),
-              subtitle: Text('感谢帮助我测试的弹幕委员会群友们\n感谢pixiv cat站主提供的图床'),
+              subtitle: Text('感谢帮助我测试的弹幕委员会群友们\n感谢 pixiv cat 站主提供的图床'),
               onTap: () {
                 if (Platform.isAndroid)
                   Navigator.of(context).push(

--- a/lib/page/about/about_page.dart
+++ b/lib/page/about/about_page.dart
@@ -203,6 +203,7 @@ class _AboutPageState extends State<AboutPage> {
                       child: Container(
                         width: 80,
                         child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           crossAxisAlignment: CrossAxisAlignment.center,
                           children: [
                             Column(
@@ -212,7 +213,7 @@ class _AboutPageState extends State<AboutPage> {
                                   backgroundImage: NetworkImage(data.avatar),
                                 ),
                                 Padding(
-                                  padding: const EdgeInsets.all(8.0),
+                                  padding: const EdgeInsets.all(8.0).copyWith(bottom: 0),
                                   child: Text(
                                     data.name,
                                     textAlign: TextAlign.center,

--- a/lib/page/about/about_page.dart
+++ b/lib/page/about/about_page.dart
@@ -193,6 +193,7 @@ class _AboutPageState extends State<AboutPage> {
                 itemBuilder: (context, index) {
                   final data = contributors[index];
                   return Card(
+                    clipBehavior: .hardEdge,
                     child: InkWell(
                       onTap: () async {
                         try {
@@ -383,6 +384,7 @@ class _AboutPageState extends State<AboutPage> {
                 subtitle: Text(I18n.of(context).donate_message),
               ),
               Card(
+                clipBehavior: .hardEdge,
                 child: ListTile(
                   title: Text('AliPay'),
                   subtitle: Text('912756674@qq.com'),
@@ -390,6 +392,7 @@ class _AboutPageState extends State<AboutPage> {
                 ),
               ),
               Card(
+                clipBehavior: .hardEdge,
                 child: ListTile(
                   title: Text('Wechat Pay'),
                   subtitle: Text('tap'),


### PR DESCRIPTION
<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="591" height="1280" alt="image" src="https://github.com/user-attachments/assets/90d47501-2491-4f76-bf0a-cb8a7e5503f7" />

 <td>
<img width="591" height="1280" alt="image" src="https://github.com/user-attachments/assets/ee46671e-293d-4987-b896-94cd43ee7331" />

</table>