### PR TITLE
feat(illust_card): adjust overlay badge design

### DIFF
--- a/lib/component/illust_card.dart
+++ b/lib/component/illust_card.dart
@@ -280,7 +280,7 @@ class _IllustCardState extends State<IllustCard> {
         borderRadius: BorderRadius.all(Radius.circular(4.0)),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 2.0, horizontal: 2.0),
+        padding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 4.0),
         child: Text("AI", style: TextStyle(color: Colors.white)),
       ),
     );
@@ -462,8 +462,8 @@ class _IllustCardState extends State<IllustCard> {
           child: Container(
             child: Padding(
               padding: const EdgeInsets.symmetric(
-                vertical: 2.0,
-                horizontal: 2.0,
+                vertical: 0.0,
+                horizontal: 4.0,
               ),
               child: cardText(),
             ),


### PR DESCRIPTION
<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="70" height="49" alt="image" src="https://github.com/user-attachments/assets/fa1ac6ba-86b3-4ea8-8fed-8183e39fc219" />

 <td>
<img width="65" height="43" alt="image" src="https://github.com/user-attachments/assets/7062ab8d-4013-429d-a323-15ccf2d2ee4d" />

</table>